### PR TITLE
Support environment activation hooks; add an SSH keypair generation hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DIST := dist
-MODULES := flight-starter flight-core flight-desktop flight-howto
+MODULES := flight-starter flight-core flight-desktop flight-howto ssh-keypair-generation
 VERSION := $(shell git describe --tags --dirty --always)
 KERNEL := $(shell uname -s)
 ARCH := $(shell uname -p)

--- a/flight-core/Makefile
+++ b/flight-core/Makefile
@@ -15,7 +15,7 @@ $(EXE):
 	go build -v $(LD_FLAGS) -o $(EXE)
 
 assets:
-	rsync -rlptgo $(ASSET_DIRS) $(DIST)/
+	rsync -rlptgo --exclude .gitkeep $(ASSET_DIRS) $(DIST)/
 
 clean:
 	rm -f $(EXE)

--- a/flight-core/hooks.go
+++ b/flight-core/hooks.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/log"
+	"github.com/urfave/cli/v3"
+)
+
+func hookPath(hook string) string {
+	return filepath.Join(hookDir, hook)
+}
+
+func transformHookError(hook string, err error) error {
+	if pathError, ok := errors.AsType[*fs.PathError](err); ok {
+		if pathError.Err.Error() == "no such file or directory" {
+			return UnknownHook{Hook: hook}
+		}
+	}
+	return err
+}
+
+func listHooks(_ context.Context, cmd *cli.Command) error {
+	onlyEnabled := cmd.Bool("enabled")
+	hooks, err := getHooks(onlyEnabled)
+	if err != nil {
+		return err
+	}
+	for _, hook := range hooks {
+		fmt.Println(hook)
+	}
+	return nil
+}
+
+func getHooks(onlyEnabled bool) ([]string, error) {
+	log.Debug("getting hooks", "dir", hookDir, "onlyEnabled", onlyEnabled)
+	entries, err := os.ReadDir(hookDir)
+	if err != nil {
+		return nil, fmt.Errorf("listing hooks: %w", err)
+	}
+	hooks := make([]string, 0)
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		if onlyEnabled {
+			info, err := entry.Info()
+			if err != nil {
+				return nil, fmt.Errorf("reading hook info: %w", err)
+			}
+			if info.Mode()&0111 != 0 {
+				hooks = append(hooks, entry.Name())
+			}
+		} else {
+			hooks = append(hooks, entry.Name())
+		}
+	}
+	return hooks, nil
+}
+
+func enableHook(ctx context.Context, cmd *cli.Command) error {
+	hook := cmd.StringArg("hook")
+	hp := hookPath(hook)
+	log.Debug("Enabling", "hook", hook, "path", hp)
+	if strings.HasPrefix(hook, ".") {
+		return UnknownHook{Hook: hook}
+	}
+	if err := os.Chmod(hp, 0755); err != nil {
+		return transformHookError(hook, err)
+	}
+	log.Printf("Enabled %s hook", hook)
+	return nil
+}
+
+func disableHook(ctx context.Context, cmd *cli.Command) error {
+	hook := cmd.StringArg("hook")
+	hp := hookPath(hook)
+	log.Debug("Disabling", "hook", hook, "path", hp)
+	if strings.HasPrefix(hook, ".") {
+		return UnknownHook{Hook: hook}
+	}
+	if err := os.Chmod(hp, 0444); err != nil {
+		return transformHookError(hook, err)
+	}
+	log.Printf("Disabled flight %s hook", hook)
+	return nil
+}
+
+type UnknownHook struct {
+	Hook string
+}
+
+func (ut UnknownHook) Error() string {
+	return fmt.Sprintf("Unknown hook: %s", ut.Hook)
+}

--- a/flight-core/main.go
+++ b/flight-core/main.go
@@ -29,6 +29,7 @@ var (
 	progName   string = "flight"
 	flightRoot string = "/opt/flight"
 	toolDir    string
+	hookDir    string
 )
 
 func init() {
@@ -39,6 +40,7 @@ func init() {
 		flightRoot = root
 	}
 	toolDir = filepath.Join(flightRoot, "usr", "lib", "flight-core")
+	hookDir = filepath.Join(flightRoot, "usr", "lib", "hooks")
 }
 
 func main() {
@@ -61,8 +63,8 @@ func main() {
 		HideHelpCommand:        true,
 		Description: wordwrap.String(
 			fmt.Sprintf(
-				"'%s' provides access to the Flight User Suite.  Any enabled tools can be accessed as '%s <tool>' and a list of enabled tools can be found with '%s tools list --enabled'.",
-				progName, progName, progName,
+				"Manage the Flight User Suite tools and hooks and access enabled tools.\n\nTools can be managed with the '%s tools' command and any enabled tools can be accessed as '%s <tool>'. A list of enabled tools can be found with '%s tools list --enabled'.\n\nHooks can be managed with the '%s hooks' command and are executed when the flight environment is activated.",
+				progName, progName, progName, progName,
 			),
 			maxTextWidth,
 		),
@@ -155,6 +157,65 @@ func main() {
 						},
 						Before: assertArgPresent("tool"),
 						Action: disableTool,
+					},
+				},
+			},
+			{
+				Name:      "hooks",
+				Usage:     "Manage Flight User Suite hooks",
+				UsageText: fmt.Sprintf("%s hooks command [command options]", progName),
+				Description: wordwrap.String(
+					"Manage the Flight User Suite hooks.\n\nWhen a hook is enabled, it is executed when the flight environment is activated.",
+					maxTextWidth,
+				),
+				Category: "Hook management",
+				Commands: []*cli.Command{
+					{
+						Name:        "list",
+						Usage:       "List Flight User Suite hooks",
+						UsageText:   fmt.Sprintf("%s hooks list [--enabled]", progName),
+						Description: wordwrap.String("List all Flight User Suite hooks.  If the --enabled flag is set, only list those hooks that are currently enabled.", maxTextWidth),
+						Flags: []cli.Flag{
+							&cli.BoolFlag{
+								Name:  "enabled",
+								Usage: "list only enabled hooks",
+							},
+						},
+						Action: listHooks,
+					},
+					{
+						Name:      "enable",
+						Usage:     "Enable a Flight User Suite hook",
+						UsageText: fmt.Sprintf("%s hooks enable <hook>", progName),
+						Description: wordwrap.String(
+							fmt.Sprintf(
+								"Enable the specified hook. When a hook is enabled, it is executed when the flight environment is activated.\n\nA list of available hooks can be found with '%s hooks list'.",
+								progName,
+							),
+							maxTextWidth,
+						),
+						Arguments: []cli.Argument{
+							&cli.StringArg{Name: "hook"},
+						},
+						Before: assertArgPresent("hook"),
+						Action: enableHook,
+					},
+					{
+						Name:      "disable",
+						Usage:     "Disable a Flight User Suite hook",
+						UsageText: fmt.Sprintf("%s hooks disable <hook>", progName),
+						Description: wordwrap.String(
+							fmt.Sprintf(
+								"When a hook is disabled, it is no longer executed when the flight environment is activated.\n\nA list of currently enabled hooks can be found with '%s hooks list --enabled'.",
+								progName,
+							),
+							maxTextWidth,
+						),
+						Arguments: []cli.Argument{
+							&cli.StringArg{Name: "hook"},
+						},
+						Before: assertArgPresent("hook"),
+						Action: disableHook,
 					},
 				},
 			},

--- a/flight-desktop/Makefile
+++ b/flight-desktop/Makefile
@@ -6,7 +6,7 @@ ASSET_DIRS := opt
 all: assets
 
 assets:
-	rsync -rlptgo $(ASSET_DIRS) $(DIST)/
+	rsync -rlptgo --exclude .gitkeep $(ASSET_DIRS) $(DIST)/
 
 clean:
 

--- a/flight-howto/Makefile
+++ b/flight-howto/Makefile
@@ -6,7 +6,7 @@ ASSET_DIRS := opt
 all: assets
 
 assets:
-	rsync -rlptgo $(ASSET_DIRS) $(DIST)/
+	rsync -rlptgo --exclude .gitkeep $(ASSET_DIRS) $(DIST)/
 
 clean:
 

--- a/flight-starter/Makefile
+++ b/flight-starter/Makefile
@@ -6,7 +6,7 @@ ASSET_DIRS := etc opt
 all: assets
 
 assets:
-	rsync -rlptgo $(ASSET_DIRS) $(DIST)/
+	rsync -rlptgo --exclude .gitkeep $(ASSET_DIRS) $(DIST)/
 
 clean:
 

--- a/flight-starter/opt/flight/etc/profile.d/03-hooks.sh
+++ b/flight-starter/opt/flight/etc/profile.d/03-hooks.sh
@@ -1,0 +1,11 @@
+# Run any enabled hooks when the Flight environment is activated.
+if [ -d "${FLIGHT_ROOT}"/usr/lib/hooks ]; then
+  shopt -s nullglob
+  for hook in "${FLIGHT_ROOT}"/usr/lib/hooks/*; do
+      if [ -x "${hook}" ] ; then
+          "${hook}"
+      fi
+  done
+  shopt -u nullglob
+fi
+unset hook

--- a/ssh-keypair-generation/Makefile
+++ b/ssh-keypair-generation/Makefile
@@ -1,0 +1,14 @@
+DIST := dist
+ASSET_DIRS := opt
+
+.PHONY: all assets clean distclean
+
+all: assets
+
+assets:
+	rsync -rlptgo --exclude .gitkeep $(ASSET_DIRS) $(DIST)/
+
+clean:
+
+distclean: clean
+	rm -rf $(DIST)

--- a/ssh-keypair-generation/README.md
+++ b/ssh-keypair-generation/README.md
@@ -1,0 +1,11 @@
+# SSH keypair generation
+
+SSH keypair generation is a hook that generates a passless SSH key that can be
+used to SSH around the cluster.  Ensuring that the key is authorised on each
+node is outside the scope of this hook; we assume that adding it to
+`~/.ssh/authorized_keys` is sufficient.
+
+## Usage
+
+* Enable the hook: `/opt/flight/bin/flight hooks enable ssh-keypair-generation`.
+* Activate the flight environment: `flight-start`.

--- a/ssh-keypair-generation/opt/flight/etc/ssh-keypair-generation.config
+++ b/ssh-keypair-generation/opt/flight/etc/ssh-keypair-generation.config
@@ -1,0 +1,5 @@
+FLIGHT_SSH_LOWEST_UID=500
+FLIGHT_SSH_SKIP_USERS="root"
+FLIGHT_SSH_KEYNAME=id_flightcluster
+FLIGHT_SSH_DIR="$HOME/.ssh"
+FLIGHT_SSH_LOG="$HOME/.cache/flight/ssh-keypair-generation.log"

--- a/ssh-keypair-generation/opt/flight/usr/lib/hooks/ssh-keypair-generation
+++ b/ssh-keypair-generation/opt/flight/usr/lib/hooks/ssh-keypair-generation
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+is_target_user() {
+    if [ ${FLIGHT_SSH_LOWEST_UID} -gt ${UID} ]; then
+        return 1
+    fi
+    for u in ${FLIGHT_SSH_SKIP_USERS}; do
+        if [ "$(id -un)" ==  "${u}" ]; then
+            return 1
+        fi
+    done
+}
+
+has_existing_key() {
+    if ! [ -f "${FLIGHT_SSH_DIR}"/"${FLIGHT_SSH_KEYNAME}.pub" -a -f "${FLIGHT_SSH_DIR}"/"${FLIGHT_SSH_KEYNAME}" ]; then
+        return 1
+    fi
+}
+
+create_key() {
+    echo "GENERATING SSH KEYPAIR - $(date)"
+    /usr/bin/ssh-keygen -q -t rsa \
+        -f "${FLIGHT_SSH_DIR}"/"${FLIGHT_SSH_KEYNAME}" \
+        -C "Flight HPC Cluster Key" \
+        -N '' < /dev/null
+}
+
+enable_key() {
+    echo "AUTHORIZING KEYS - $(date)"
+    cat "${FLIGHT_SSH_DIR}"/"${FLIGHT_SSH_KEYNAME}".pub >> "${FLIGHT_SSH_DIR}"/authorized_keys
+    chmod 600 "${FLIGHT_SSH_DIR}"/authorized_keys
+}
+
+new_config() {
+    local updating_config
+    if [ -f "${FLIGHT_SSH_DIR}/config" ]; then
+        echo "UPDATING CONFIG"
+        updating_config=true
+    else
+        echo "CREATING CONFIG"
+        updating_config=false
+    fi
+    # Add the new configuration to the top of the file (if it exists).  The
+    # standard unix tools make that a pain to accomplish without resorting to
+    # temp files or partially writting out the config.  So we use `ex`.  It's
+    # part of the posix standard.
+    ex "${FLIGHT_SSH_DIR}/config" <<EOF
+1 insert
+Host *
+  IdentityFile ${FLIGHT_SSH_DIR}/${FLIGHT_SSH_KEYNAME}
+  StrictHostKeyChecking  no
+.
+xit
+EOF
+    chmod 600 "${FLIGHT_SSH_DIR}"/config
+    if [ "${updating_config}" == true ] ; then
+        cat <<WARN >&2
+Your SSH config has been modified to use the generated identity file.
+Please review the config if you experience issues with SSH.
+SSH Config:    ${FLIGHT_SSH_DIR}/config
+Identity File: ${FLIGHT_SSH_DIR}/${FLIGHT_SSH_KEYNAME}
+
+WARN
+    fi
+}
+
+main() {
+    if is_target_user && ! has_existing_key; then
+        mkdir -p "$(dirname "${FLIGHT_SSH_LOG}")"
+        echo -n "Generating SSH keypair: "
+        if create_key >> "${FLIGHT_SSH_LOG}"; then
+            echo 'OK'
+            echo -n "Authorizing key: "
+            if enable_key >> "${FLIGHT_SSH_LOG}"; then
+                echo 'OK'
+                echo
+                new_config >> "${FLIGHT_SSH_LOG}"
+            else
+                echo 'FAIL'
+                echo
+            fi
+        else
+            echo 'FAIL'
+        fi
+    fi
+}
+
+FLIGHT_ROOT=${FLIGHT_ROOT:-/opt/flight}
+
+if [ -f "${FLIGHT_ROOT}"/etc/ssh-keypair-generation.config ]; then
+    . "${FLIGHT_ROOT}"/etc/ssh-keypair-generation.config
+fi
+
+FLIGHT_SSH_LOWEST_UID=${FLIGHT_SSH_LOWEST_UID:-500}
+FLIGHT_SSH_SKIP_USERS="${FLIGHT_SSH_SKIP_USERS:-root}"
+FLIGHT_SSH_KEYNAME="${FLIGHT_SSH_KEYNAME:-id_flightcluster}"
+FLIGHT_SSH_DIR="${FLIGHT_SSH_DIR:-$HOME/.ssh}"
+FLIGHT_SSH_LOG="${FLIGHT_SSH_LOG:-$HOME/.cache/flight/ssh-keypair-generation.log}"
+
+main


### PR DESCRIPTION
This PR adds support for environment activation hooks. These are executables that are executed automatically when the flight environment is activated.  Similarly, to tools, they can be listed, enabled and disabled.

```bash
flight hooks list [--enabled]
flight hooks enable <hook>
flight hooks disable <hook>
```

This PR also adds an SSH keypair generation hook that generates a passwordless SSH keypair for the user unless that has already been done.  This hook has been added as its own subproject but could easily have been folded into the flight-starter subproject.