### PR TITLE
Publish (but not release) built tarball every build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Build
         run: make
 
+      - name: Publish build tarball
+        uses: actions/upload-artifact@v7
+        with:
+          path: flight-user-suite*.tar.gz
+          archive: false
+
       - name: Release
         uses: softprops/action-gh-release@v2
         if: ${{ github.ref_type == 'tag' }}


### PR DESCRIPTION
Tweak to the GH workflow to make the tarball we build downloadable from the action.