### PR TITLE
Improve modified Flight prompt.

### DIFF
--- a/flight-starter/opt/flight/etc/profile.d/02-prompt.sh
+++ b/flight-starter/opt/flight/etc/profile.d/02-prompt.sh
@@ -1,26 +1,18 @@
 export FLIGHT_ORIG_ENV_PS1="${PS1}"
 
-if [ "$PS1" = "\\s-\\v\\\$ " ]; then
-  # Prompt hasn't been set yet, give it a default
-  PS1="[\u@\h \W]\\$ "
-fi
+FLIGHT_ORANGE="38;2;255;116;1"
+
+# Start with the basics - we'll end up injecting a space between \h and \W later
+PS1="[\u@\h\W]\\$ "
+
+# Prepend an orange <flight>
+PS1="\[\033[${FLIGHT_ORANGE}m\]\$(__flight_ps1_active \"<%s>\")\[\033[00m\] ${PS1}"
 
 FLIGHT_PS1="$(
     "${FLIGHT_ROOT}"/libexec/flight-starter/augment-bash-prompt \
         "$PS1" \
-        '$(__flight_ps1_active "<%s>")' \
-        '1;32;40' \
-        2>/dev/null
-    )"
-if [ $? -eq 0 ] ; then
-    PS1="${FLIGHT_PS1}"
-fi
-
-FLIGHT_PS1="$(
-    "${FLIGHT_ROOT}"/libexec/flight-starter/augment-bash-prompt \
-        "$PS1" \
-        '$(__flight_ps1_clustername)' \
-        '1;32;40' \
+        '$(__flight_ps1_clustername "(%s) ")' \
+        "$FLIGHT_ORANGE" \
         2>/dev/null
     )"
 if [ $? -eq 0 ] ; then
@@ -60,7 +52,7 @@ __flight_ps1_active() {
 
     local flight_string
     if [ "${FLIGHT_ACTIVE}" == "true" ] ; then
-        flight_string="Flight env active"
+        flight_string="flight"
     fi
 
     if [ "${flight_string}" != "" ]; then
@@ -69,4 +61,4 @@ __flight_ps1_active() {
 }
 
 FLIGHT_DEFINED_SYMBOLS+=(__flight_ps1_active __flight_ps1_clustername)
-unset FLIGHT_PS1
+unset FLIGHT_PS1 FLIGHT_ORANGE


### PR DESCRIPTION
- Shorten "Flight env active" to "Flight"
- Highlight it and cluster name in Concertim orange

<img width="757" height="105" alt="image" src="https://github.com/user-attachments/assets/dc9d7f49-6e59-44b7-bee3-d96a06b1a980" />

We now fully replace the existing prompt, rather than adding bits to the existing one. This means we can guarantee the format of the final prompt. (Perhaps we want to be more accommodating to users' preferences though?)

We go to a little effort to make sure an empty/default cluster name doesn't result in a double space in the middle of the prompt.

I could have gone a step further and removed the need for the `augment-bash-prompt` Python script but I didn't.

Resolves #27.