### PR TITLE
Add `kill` command

### DIFF
--- a/flight-desktop/main.go
+++ b/flight-desktop/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -87,6 +88,7 @@ func main() {
 		},
 		Commands: []*cli.Command{
 			startCommand(),
+			killSessionCommand(),
 		},
 	}
 
@@ -124,8 +126,12 @@ func main() {
 			os.Exit(1)
 		}
 
-		log.Printf("%s\n", err)
-		os.Exit(1)
+		if exitError, ok := errors.AsType[SilentExitError](err); ok {
+			os.Exit(exitError.ExitCode)
+		} else {
+			log.Printf("%s\n", err)
+			os.Exit(1)
+		}
 	}
 }
 

--- a/flight-desktop/session_kill.go
+++ b/flight-desktop/session_kill.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"charm.land/log/v2"
+	"github.com/google/uuid"
+	"github.com/muesli/reflow/wordwrap"
+	"github.com/urfave/cli/v3"
+	"gopkg.in/yaml.v3"
+)
+
+func killSessionCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "kill",
+		Usage:       "Terminate an interactive desktop session",
+		Description: wordwrap.String(fmt.Sprintf("Instruct an active interactive desktop session to terminate.\n\nThe <id> parameter should specify the session identity, use '%s list' to see a list of your sessions.", progName), 80),
+		Arguments: []cli.Argument{
+			&cli.StringArg{Name: "id", UsageText: "<id>"},
+		},
+		Before: assertArgPresent("id"),
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			id := cmd.StringArg("id")
+			session, err := loadSession(id)
+			if err != nil {
+				if err2 := session.RemoveSessionDir(); err2 != nil {
+					log.Debug("Removing session dir", "sessionDir", session.sessionDir(), "err", err2)
+				}
+				return err
+			}
+			// TODO: Display a spinner.
+			fmt.Printf("Killing desktop session %s\n", session.UUID.String())
+			err = session.Kill(ctx)
+			// TODO: Stop the spinner
+			if err != nil {
+				fmt.Printf("\u274c Terminating session\n\n")
+				return fmt.Errorf("terminating session: %w", err)
+			}
+			fmt.Printf("\u2705 Terminating session\n\n")
+			fmt.Printf("Desktop session '%s' has been terminated.\n", session.UUID.String())
+			return nil
+		},
+	}
+}
+
+func loadSession(id string) (*Session, error) {
+	session := &Session{UUID: uuid.MustParse(id)}
+	log.Debug("Loading session", "sessionDir", session.sessionDir())
+	info, err := os.Stat(session.sessionDir())
+	if err != nil {
+		log.Debug("Error checking session dir", "sessionDir", session.sessionDir(), "err", err)
+		session.SessionState = Broken
+		return session, UnknownSession{Session: id}
+	}
+	if !info.IsDir() {
+		log.Debug("Session dir is not a directory", "sessionDir", session.sessionDir())
+		session.SessionState = Broken
+		return session, UnknownSession{Session: id}
+	}
+
+	data, err := os.ReadFile(session.metadataFile())
+	if err != nil {
+		log.Debug("Reading session metadata", "metadataFile", session.metadataFile(), "err", err)
+		session.SessionState = Broken
+		return session, nil
+	}
+	err = yaml.Unmarshal(data, &session)
+	if err != nil {
+		log.Debug("Loading session metadata", "metadataFile", session.metadataFile(), "err", err)
+		session.SessionState = Broken
+		return session, nil
+	}
+	return session, nil
+}
+
+type UnknownSession struct {
+	Session string
+}
+
+func (us UnknownSession) Error() string {
+	return fmt.Sprintf("Unknown session: %s", us.Session)
+}

--- a/flight-desktop/start.go
+++ b/flight-desktop/start.go
@@ -108,6 +108,7 @@ type sessionState string
 var (
 	New    sessionState = "new"
 	Active sessionState = "active"
+	Broken sessionState = "broken"
 )
 
 type Session struct {
@@ -119,6 +120,33 @@ type Session struct {
 	Geometry     string          `yaml:"geometry"`
 	CreatedAt    time.Time       `yaml:"created_at"`
 	Metadata     sessionMetadata `yaml:"metadata"`
+}
+
+func (s *Session) Kill(ctx context.Context) error {
+	args := []string{
+		"-kill",
+		"-sessiondir", s.sessionDir(),
+	}
+	cmd := exec.CommandContext(ctx, libexecPath("vncserver"), args...)
+	// TODO: Set environment.
+	// cmd.Env = []string{}
+	output, err := cmd.CombinedOutput()
+	if exitError, ok := errors.AsType[*exec.ExitError](err); ok {
+		log.Debug("vncserver", "stdout/stderr", string(output))
+		return SilentExitError{ExitCode: exitError.ExitCode(), exitError: exitError}
+	} else if err != nil {
+		log.Debug("vncserver", "stdout/stderr", string(output))
+		return fmt.Errorf("killing VNC server: %w", err)
+	}
+	return s.RemoveSessionDir()
+}
+
+func (s *Session) RemoveSessionDir() error {
+	err := os.RemoveAll(s.sessionDir())
+	if err != nil {
+		return fmt.Errorf("removing session dir: %w", err)
+	}
+	return nil
 }
 
 type sessionMetadata struct {
@@ -290,4 +318,14 @@ func (s *Session) save() error {
 	log.Debug("saving session", "file", metadataFile)
 	os.WriteFile(metadataFile, data, 0o600)
 	return nil
+}
+
+// Wrapper around exec.ExitError that avoids the default handling by urfave/cli.
+type SilentExitError struct {
+	ExitCode  int
+	exitError error
+}
+
+func (ee SilentExitError) Error() string {
+	return ee.exitError.Error()
 }


### PR DESCRIPTION
This PR adds a `kill <id>` command which will kill an active session by running `vncserver -kill -sessiondir ...` and if successful remove its session directory.

If the session cannot be loaded due to missing files or directories, log why and remove the session directory.

If the session cannot be loaded due to a bad metadata file, log why, attempt to kill the vncserver and if that's successful remove the session directory.  If there is a `vncserver.pid` file in the session directory, it may be possible to kill the session even if the `metadata.yml` file has become corrupted FSR.

<img width="538" height="77" alt="image" src="https://github.com/user-attachments/assets/eb7b062f-0e83-440d-aab0-2e30917bc8e0" />
