### PR TITLE
List and show sessions

### DIFF
--- a/flight-desktop/main.go
+++ b/flight-desktop/main.go
@@ -92,6 +92,7 @@ func main() {
 			startCommand(),
 			listSessionsCommand(),
 			killSessionCommand(),
+			showSessionCommand(),
 		},
 	}
 

--- a/flight-desktop/main.go
+++ b/flight-desktop/main.go
@@ -26,6 +26,7 @@ var (
 
 	progName     string = "flight desktop"
 	flightRoot   string = "/opt/flight"
+	termWidth    int    = 80
 	maxTextWidth int    = 80
 )
 
@@ -36,7 +37,8 @@ func init() {
 	if root, ok := os.LookupEnv("FLIGHT_ROOT"); ok {
 		flightRoot = root
 	}
-	termWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
+	var err error
+	termWidth, _, err = term.GetSize(int(os.Stdout.Fd()))
 	if err != nil {
 		termWidth = 80
 	}
@@ -88,6 +90,7 @@ func main() {
 		},
 		Commands: []*cli.Command{
 			startCommand(),
+			listSessionsCommand(),
 			killSessionCommand(),
 		},
 	}

--- a/flight-desktop/session.go
+++ b/flight-desktop/session.go
@@ -39,6 +39,56 @@ type Session struct {
 	Metadata     sessionMetadata `yaml:"metadata"`
 }
 
+func loadAllSessions() ([]*Session, error) {
+	glob := filepath.Join(xdg.StateHome, "flight", "desktop", "sessions", "*", "metadata.yml")
+	log.Debug("Loading all sessions", "glob", glob)
+	sessions := make([]*Session, 0)
+	matches, err := filepath.Glob(glob)
+	if err != nil {
+		return nil, fmt.Errorf("loading sessions: %w", err)
+	}
+	for _, match := range matches {
+		id := filepath.Base(filepath.Dir(match))
+		session, err := loadSession(id)
+		if err != nil {
+			log.Debug("Skipping bad session", "match", match, "err", err)
+			continue
+		}
+		sessions = append(sessions, session)
+	}
+	return sessions, nil
+}
+
+func loadSession(id string) (*Session, error) {
+	session := &Session{ID: id}
+	log.Debug("Loading session", "sessionDir", session.sessionDir())
+	info, err := os.Stat(session.sessionDir())
+	if err != nil {
+		log.Debug("Error checking session dir", "sessionDir", session.sessionDir(), "err", err)
+		session.SessionState = Broken
+		return session, UnknownSession{Session: id}
+	}
+	if !info.IsDir() {
+		log.Debug("Session dir is not a directory", "sessionDir", session.sessionDir())
+		session.SessionState = Broken
+		return session, UnknownSession{Session: id}
+	}
+
+	data, err := os.ReadFile(session.metadataFile())
+	if err != nil {
+		log.Debug("Reading session metadata", "metadataFile", session.metadataFile(), "err", err)
+		session.SessionState = Broken
+		return session, nil
+	}
+	err = yaml.Unmarshal(data, &session)
+	if err != nil {
+		log.Debug("Loading session metadata", "metadataFile", session.metadataFile(), "err", err)
+		session.SessionState = Broken
+		return session, nil
+	}
+	return session, nil
+}
+
 func (s *Session) Start(ctx context.Context) error {
 	if err := s.mkSessionDir(); err != nil {
 		return err
@@ -114,6 +164,14 @@ func (s Session) Port() int {
 		return -1
 	}
 	return 5900 + display
+}
+
+func (s Session) PrimaryConnectionString() string {
+	if s.SessionState == Broken {
+		return ""
+	}
+	ip := s.PrimaryIP().String()
+	return fmt.Sprintf("%s:%d", ip, s.Port())
 }
 
 func (s Session) Display() string {

--- a/flight-desktop/session_details.go
+++ b/flight-desktop/session_details.go
@@ -20,7 +20,7 @@ func printSessionStartedMessage(session Session) {
 	}
 	ip := session.PrimaryIP().String()
 	vnc := fmt.Sprintf("vnc://%s:%s@%s:%d", username, session.Password, ip, session.Port())
-	ipPort := fmt.Sprintf("%s:%d", ip, session.Port())
+	ipPort := session.PrimaryConnectionString()
 	ipDisplay := fmt.Sprintf("%s:%s", ip, session.Display())
 
 	var name string

--- a/flight-desktop/session_details.go
+++ b/flight-desktop/session_details.go
@@ -5,11 +5,55 @@ import (
 	"os/user"
 	"time"
 
+	"charm.land/lipgloss/v2"
 	"charm.land/log/v2"
-	"github.com/muesli/reflow/wordwrap"
 )
 
-func printSessionStartedMessage(session Session) {
+func sessionStarted(session *Session) {
+	bold := lipgloss.NewStyle().Bold(true)
+	var name string
+	if session.Name != "" {
+		name = lipgloss.JoinHorizontal(lipgloss.Top, "(", bold.Render(session.Name), ") ")
+	}
+	out := lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		"A new desktop session ",
+		name,
+		"has been started. To connect, use the details below:",
+	)
+	out = lipgloss.Wrap(out, maxTextWidth, " ")
+	lipgloss.Println(out)
+}
+
+func sessionInfo(session *Session) {
+	dt := lipgloss.NewStyle().Foreground(ctmOrange).Padding(0, 2, 0, 1)
+	dd := lipgloss.NewStyle().Foreground(lightDark(primary, cream))
+	metadata := lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		lipgloss.JoinVertical(
+			lipgloss.Right,
+			dt.Render("Name"),
+			dt.Render("Type"),
+			dt.Render("Screen size"),
+			dt.Render("Started at"),
+		),
+		lipgloss.JoinVertical(
+			lipgloss.Left,
+			dd.Render(session.Name),
+			dd.Render(session.SessionType),
+			dd.Render(session.Geometry),
+			dd.Render(session.CreatedAt.Format(time.RFC822)),
+		),
+	)
+	out := lipgloss.JoinVertical(
+		lipgloss.Left,
+		header.Render("Session Details"),
+		metadata,
+	)
+	lipgloss.Println(out)
+}
+
+func connectionInfo(session *Session) {
 	var username string
 	u, err := user.Current()
 	if u == nil {
@@ -23,11 +67,42 @@ func printSessionStartedMessage(session Session) {
 	ipPort := session.PrimaryConnectionString()
 	ipDisplay := fmt.Sprintf("%s:%s", ip, session.Display())
 
-	var name string
-	if session.Name != "" {
-		name = fmt.Sprintf("(%s) ", session.Name)
-	}
-	out := fmt.Sprintf("A new desktop session %shas been started. To connect, use the details below:\n\n1. Connection Address\n\nCopy and paste the first address into your VNC viewer. If that doesn't work, try one of the alternatives:\n\n* Primary:       %s\n* Alternative 1: %s\n* Alternative 2: %s\n\n2. Password\n\nIf prompted, use this password: %s\n\n3. Need Help?\n\nFor a more details on how to connect, run: 'flight howto show flight-desktop'\n\n4. Manage this session\n\nTo view details or stop this session later, you will need the Session ID:\n\n    %s\n\n(Tip: Run 'flight desktop --help' to see management commands)\n\nStarted at: %s\n", name, ipPort, vnc, ipDisplay, session.Password, session.ID, session.CreatedAt.Format(time.RFC822))
-	out = wordwrap.String(out, 80)
-	fmt.Print(out)
+	out := lipgloss.JoinVertical(
+		lipgloss.Left,
+		header.Render("Connection Details"),
+		subheader.Render("1. Connection address"),
+		paragraph.Render(lipgloss.Wrap("Copy and paste the first address into your VNC viewer. If that doesn't work, try one of the alternatives:", maxTextWidth, " -")),
+		lipgloss.JoinHorizontal(
+			lipgloss.Top,
+			lipgloss.JoinVertical(
+				lipgloss.Left,
+				bullet.Render("* Primary:"),
+				bullet.Render("* Alternative 1:"),
+				bullet.Render("* Alternative 2:"),
+			),
+			lipgloss.JoinVertical(
+				lipgloss.Left,
+				ipPort,
+				vnc,
+				ipDisplay,
+			),
+		),
+		subheader.PaddingTop(1).Render("2. Password"),
+		lipgloss.JoinHorizontal(
+			lipgloss.Top,
+			paragraph.Render("If prompted, use this password:"),
+			code.Render(session.Password),
+		),
+		subheader.Render("3. Need Help?"),
+		lipgloss.JoinHorizontal(
+			lipgloss.Top,
+			paragraph.Render("For more details on how to connect, run:"),
+			code.Render("flight howto show flight-desktop"),
+		),
+		header.MarginTop(0).Render("Manage this session"),
+		paragraph.PaddingBottom(0).Render("To view details or stop this session later, you will need the Session ID:"),
+		code.Margin(0, 0, 1, 1).Render(session.ID),
+		paragraph.Render("(Tip: Run 'flight desktop --help' to see management commands)"),
+	)
+	lipgloss.Println(out)
 }

--- a/flight-desktop/session_kill.go
+++ b/flight-desktop/session_kill.go
@@ -3,12 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"charm.land/log/v2"
 	"github.com/muesli/reflow/wordwrap"
 	"github.com/urfave/cli/v3"
-	"gopkg.in/yaml.v3"
 )
 
 func killSessionCommand() *cli.Command {
@@ -42,36 +40,6 @@ func killSessionCommand() *cli.Command {
 			return nil
 		},
 	}
-}
-
-func loadSession(id string) (*Session, error) {
-	session := &Session{ID: id}
-	log.Debug("Loading session", "sessionDir", session.sessionDir())
-	info, err := os.Stat(session.sessionDir())
-	if err != nil {
-		log.Debug("Error checking session dir", "sessionDir", session.sessionDir(), "err", err)
-		session.SessionState = Broken
-		return session, UnknownSession{Session: id}
-	}
-	if !info.IsDir() {
-		log.Debug("Session dir is not a directory", "sessionDir", session.sessionDir())
-		session.SessionState = Broken
-		return session, UnknownSession{Session: id}
-	}
-
-	data, err := os.ReadFile(session.metadataFile())
-	if err != nil {
-		log.Debug("Reading session metadata", "metadataFile", session.metadataFile(), "err", err)
-		session.SessionState = Broken
-		return session, nil
-	}
-	err = yaml.Unmarshal(data, &session)
-	if err != nil {
-		log.Debug("Loading session metadata", "metadataFile", session.metadataFile(), "err", err)
-		session.SessionState = Broken
-		return session, nil
-	}
-	return session, nil
 }
 
 type UnknownSession struct {

--- a/flight-desktop/session_list.go
+++ b/flight-desktop/session_list.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"charm.land/lipgloss/v2"
+	"charm.land/lipgloss/v2/table"
+	"github.com/muesli/reflow/wordwrap"
+	"github.com/urfave/cli/v3"
+)
+
+func listSessionsCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "list",
+		Usage:       "List interactive desktop sessions",
+		Description: wordwrap.String("Display all known desktop sessions and their states.", 80),
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			sessions, err := loadAllSessions()
+			if err != nil {
+				return err
+			}
+			if len(sessions) == 0 {
+				fmt.Println("No desktop sessions found.")
+				return nil
+			}
+			err = sessionsTable(sessions)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+}
+
+func sessionsTable(sessions []*Session) error {
+	t := table.New().
+		Border(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(ctmOrange)).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			var style lipgloss.Style
+			switch {
+			case row == table.HeaderRow:
+				return tableHeaderStyle
+			case row%2 == 0:
+				style = tableEvenRowStyle
+			default:
+				style = tableOddRowStyle
+			}
+			return style
+		}).
+		Width(termWidth)
+	t.Headers("Name", "Type", "Connection string", "Password", "State", "ID")
+	for _, s := range sessions {
+		t.Row(
+			s.Name,
+			s.SessionType,
+			s.PrimaryConnectionString(),
+			s.Password,
+			string(s.SessionState),
+			s.ID,
+		)
+	}
+	_, err := lipgloss.Println(t)
+	return err
+}

--- a/flight-desktop/session_show.go
+++ b/flight-desktop/session_show.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+
+	"charm.land/log/v2"
+	"github.com/muesli/reflow/wordwrap"
+	"github.com/urfave/cli/v3"
+)
+
+func showSessionCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "show",
+		Usage:       "Show information about a desktop session",
+		Description: wordwrap.String("Display the connection information for a desktop session.", maxTextWidth),
+		Arguments: []cli.Argument{
+			&cli.StringArg{Name: "id", UsageText: "<id>"},
+		},
+		Before: assertArgPresent("id"),
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			id := cmd.StringArg("id")
+			session, err := loadSession(id)
+			if err != nil {
+				if err2 := session.RemoveSessionDir(); err2 != nil {
+					log.Debug("Removing session dir", "sessionDir", session.sessionDir(), "err", err2)
+				}
+				return err
+			}
+			sessionInfo(session)
+			connectionInfo(session)
+			return nil
+		},
+	}
+}

--- a/flight-desktop/session_start.go
+++ b/flight-desktop/session_start.go
@@ -67,7 +67,8 @@ func startCommand() *cli.Command {
 				return fmt.Errorf("starting session: %w", err)
 			}
 			fmt.Printf("\u2705 Your %s session is ready!\n\n", session.SessionType)
-			printSessionStartedMessage(session)
+			sessionStarted(&session)
+			connectionInfo(&session)
 			return nil
 		},
 	}

--- a/flight-desktop/theme.go
+++ b/flight-desktop/theme.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+
+	"charm.land/lipgloss/v2"
+)
+
+var (
+	black     = lipgloss.Color("#000000")
+	cream     = lipgloss.Color("#FFFDF5")
+	ctmOrange = lipgloss.Color("#ff7401")
+	grey      = lipgloss.Color("#CCD0DA")
+	primary   = lipgloss.Color("#2C3E50")
+
+	hasDark   = lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+	lightDark = lipgloss.LightDark(hasDark)
+
+	tableHeaderStyle  = lipgloss.NewStyle().Foreground(ctmOrange).Bold(true).Align(lipgloss.Center)
+	tableCellStyle    = lipgloss.NewStyle().Padding(0, 1)
+	tableOddRowStyle  = tableCellStyle.Foreground(lightDark(black, grey))
+	tableEvenRowStyle = tableCellStyle.Foreground(lightDark(primary, cream))
+)

--- a/flight-desktop/theme.go
+++ b/flight-desktop/theme.go
@@ -7,14 +7,20 @@ import (
 )
 
 var (
+	hasDark   = lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+	lightDark = lipgloss.LightDark(hasDark)
+
 	black     = lipgloss.Color("#000000")
 	cream     = lipgloss.Color("#FFFDF5")
 	ctmOrange = lipgloss.Color("#ff7401")
 	grey      = lipgloss.Color("#CCD0DA")
 	primary   = lipgloss.Color("#2C3E50")
 
-	hasDark   = lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
-	lightDark = lipgloss.LightDark(hasDark)
+	header    = lipgloss.NewStyle().Margin(1, 1, 1, 0).Bold(true).Foreground(ctmOrange)
+	subheader = lipgloss.NewStyle().Margin(0, 1, 1, 1).Bold(true)
+	paragraph = lipgloss.NewStyle().Margin(0, 1, 1, 1)
+	code      = lipgloss.NewStyle().Background(grey).Foreground(primary).Bold(true)
+	bullet    = lipgloss.NewStyle().PaddingLeft(1).PaddingRight(2).Bold(true)
 
 	tableHeaderStyle  = lipgloss.NewStyle().Foreground(ctmOrange).Bold(true).Align(lipgloss.Center)
 	tableCellStyle    = lipgloss.NewStyle().Padding(0, 1)


### PR DESCRIPTION
This PR adds a command to list and show sessions.  The output for the list, show and start commands have all seen improvements.

### List

<img width="928" height="422" alt="image" src="https://github.com/user-attachments/assets/8adb09ab-88b9-4532-9db2-e727192dce9b" />

A session is shown as broken, it its `markdown.yml` file exists, but cannot be read FSR.

### Show

The show command includes some very brief data about the session, intended to allow the user to have confidence that they've found the right one, and then displays the same connection information as the start command.

<img width="928" height="540" alt="image" src="https://github.com/user-attachments/assets/67f5b33b-0294-4b0e-8422-a49e0305bc4a" />


### Start

The presentation of the output for the start command has changed:

<img width="928" height="524" alt="image" src="https://github.com/user-attachments/assets/a1fdb1a1-b014-418d-84e0-99f930bd8232" />

### Graceful colour downsampling

If stdout is not a TTY, the colour codes are stripped.  Similarly, if a terminal has limited colour support the colour will be downsampled to a set it can handle.  See https://github.com/charmbracelet/lipgloss?tab=readme-ov-file#color-downsampling.

<img width="928" height="511" alt="image" src="https://github.com/user-attachments/assets/0937d603-0c25-4dab-99d5-afdaee39e023" />

<img width="928" height="541" alt="image" src="https://github.com/user-attachments/assets/e03d3f24-b9e9-41fe-a454-9b99cb2b8951" />

Resolves #36 
Resolves #35 