### PR TITLE
Add a howto for flight desktop.

### DIFF
--- a/flight-desktop/opt/flight/usr/share/doc/flight-desktop/flight-desktop.md
+++ b/flight-desktop/opt/flight/usr/share/doc/flight-desktop/flight-desktop.md
@@ -107,7 +107,7 @@ it is possible to tunnel the VNC ports to your local system for connection.
    ssh -L 5901:localhost:5901 USERNAME@HPC_ENVIRONMENT_LOGIN
    ```
 
-   Replace `5901` with the VNC port, `USERNAME` with your username and
+   - Replace `5901` with the VNC port, `USERNAME` with your username and
    `HPC_ENVIRONMENT_LOGIN` with the hostname/IP you usually use to connect to
    your HPC environment.
 1. Launch your VNC viewer application and connect to `localhost:5901` (or the

--- a/flight-desktop/opt/flight/usr/share/doc/flight-desktop/flight-desktop.md
+++ b/flight-desktop/opt/flight/usr/share/doc/flight-desktop/flight-desktop.md
@@ -1,0 +1,130 @@
+# What is Flight Desktop?
+
+Flight Desktop, the tool that empowers you to create, manage, and access virtual
+desktop sessions within your HPC cluster. This guide provides step-by-step
+instructions for users to launch, monitor, and troubleshoot their remote desktop
+environments.
+
+Flight Desktop allows users to create and manage virtual desktop sessions of
+various environment types. Key features include:
+
+- **Isolation**: Each session has its own credentials, ensuring user privacy and
+  security.
+- **Accessibility**: Sessions are accessed remotely via VNC.
+- **Collaboration**: If session details are shared, multiple users can connect
+  to the same session simultaneously, enabling training and collaborative work.
+
+## System configuration recommendations
+
+Flight desktop is ideal for running in closed HPC environments. This ensures
+that access security is strictly controlled by network and authentication
+policies.
+
+Before using Flight Desktop, verify that your system meets the following
+criteria:
+
+- SELinux is disabled or appropriately configured to allow remote connections
+- The system, network and platform firewalls are configured to allow in a range
+  of VNC ports (a range starting at `5901`)
+
+## Desktop environment support
+
+Flight Desktop comes with support for running sessions in the following
+environments:
+
+- xterm
+- Gnome
+
+Currently all sessions are backed by the X Window System.
+
+## User Guide
+
+### Prerequisites
+
+You will need to be in an active Flight Environment for the following commands
+to work. If your terminal session is not already in the environment then run:
+
+```bash
+flight-start
+```
+
+Refer to the Flight Environment documentation for further details.
+
+### Managing Sessions
+
+To view what sessions you have running:
+
+```bash
+flight desktop list
+```
+
+To start a new session of the specified type:
+
+```bash
+flight desktop start gnome --name mydesktop1
+```
+
+Replace `gnome` with the required environment type (as detailed above), and
+`mydesktop1` with your desired session name.
+
+To view connection details (IP, port, etc) for an existing session:
+
+```bash
+flight desktop show SESSION_ID
+```
+
+Replace `SESSION_ID` with the ID of the session.
+
+To kill a session:
+
+```bash
+flight desktop kill SESSION_ID
+```
+
+Replace SESSION_ID with the ID of the session.
+
+## How to connect to a session
+
+While connecting to a session can vary depending on your system, network and
+access configuration, the below provides some advice and possible methods to
+connect to a remote desktop session.
+
+### Direct
+
+If the hostname/IP and port are directly accessible from your client then
+entering the relevant details (host, port, username, password) into your VNC
+client software should lead to a successful connection.
+
+### SSH Tunnel
+
+For tightly secured environments where VNC ports may not be directly available
+it is possible to tunnel the VNC ports to your local system for connection.
+
+1. Identify the session IP and port from `flight desktop show`
+1. Use your preferred SSH client to tunnel to the VNC port:
+
+   ```bash
+   ssh -L 5901:localhost:5901 USERNAME@HPC_ENVIRONMENT_LOGIN
+   ```
+
+   Replace `5901` with the VNC port, `USERNAME` with your username and
+   `HPC_ENVIRONMENT_LOGIN` with the hostname/IP you usually use to connect to
+   your HPC environment.
+1. Launch your VNC viewer application and connect to `localhost:5901` (or the
+   port you used above).
+
+The above example will work if the `HPC_ENVIRONMENT_LOGIN` system is where the
+desktop session is running. Further tunnelling will be required if a different
+system within the HPC environment is running the session.
+
+## Troubleshooting
+
+Below are a few steps that will help identify the cause of remote desktop
+launch/access issues.
+
+- Review the "System configuration recommendations" to ensure appropriate access
+  is available to sessions.
+
+- If you have access to them, check `/var/log/secure`, `/var/log/messages` and
+  other system logs relating to your network and security configuration for any
+  related errors.

--- a/flight-howto/main.go
+++ b/flight-howto/main.go
@@ -18,6 +18,7 @@ import (
 var (
 	flightRoot string = "/opt/flight"
 	howtoDir   string
+	themeDir   string
 )
 
 func init() {
@@ -25,6 +26,7 @@ func init() {
 		flightRoot = root
 	}
 	howtoDir = filepath.Join(flightRoot, "usr", "share", "doc", "howtos-enabled")
+	themeDir = filepath.Join(flightRoot, "usr", "lib", "flight-howto", "themes")
 }
 
 func main() {
@@ -88,12 +90,10 @@ func show(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("reading howto: %w", err)
 	}
 
-	// In theory this should work; however lipgloss seems to always think my
-	// terminal has a dark background, even if that background is white.
 	isDark := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
-	theme := "light"
+	theme := filepath.Join(themeDir, "flight-light.json")
 	if isDark {
-		theme = "dark"
+		theme = filepath.Join(themeDir, "flight-dark.json")
 	}
 
 	rendered, err := glamour.Render(string(markdown), theme)

--- a/flight-howto/opt/flight/usr/lib/flight-howto/themes/flight-dark.json
+++ b/flight-howto/opt/flight/usr/lib/flight-howto/themes/flight-dark.json
@@ -1,0 +1,103 @@
+{
+  "document": {
+    "block_prefix": "\n",
+    "block_suffix": "\n",
+    "color": "252",
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "39",
+    "bold": true
+  },
+  "h1": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "228",
+    "background_color": "63",
+    "bold": true
+  },
+  "h2": {
+    "prefix": "## "
+  },
+  "h3": {
+    "prefix": "### "
+  },
+  "h4": {
+    "prefix": "#### "
+  },
+  "h5": {
+    "prefix": "##### "
+  },
+  "h6": {
+    "prefix": "###### ",
+    "color": "35",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "bold": true
+  },
+  "hr": {
+    "color": "240",
+    "format": "\n--------\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "30",
+    "underline": true
+  },
+  "link_text": {
+    "color": "35",
+    "bold": true
+  },
+  "image": {
+    "color": "212",
+    "underline": true
+  },
+  "image_text": {
+    "color": "243",
+    "format": "Image: {{.text}} →"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "203",
+    "background_color": "236"
+  },
+  "code_block": {
+    "margin": 4,
+    "theme": "solarized-dark"
+  },
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/flight-howto/opt/flight/usr/lib/flight-howto/themes/flight-light.json
+++ b/flight-howto/opt/flight/usr/lib/flight-howto/themes/flight-light.json
@@ -1,0 +1,102 @@
+{
+  "document": {
+    "block_prefix": "\n",
+    "block_suffix": "\n",
+    "color": "234",
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "27",
+    "bold": true
+  },
+  "h1": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "228",
+    "background_color": "63",
+    "bold": true
+  },
+  "h2": {
+    "prefix": "## "
+  },
+  "h3": {
+    "prefix": "### "
+  },
+  "h4": {
+    "prefix": "#### "
+  },
+  "h5": {
+    "prefix": "##### "
+  },
+  "h6": {
+    "prefix": "###### ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "bold": true
+  },
+  "hr": {
+    "color": "249",
+    "format": "\n--------\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "36",
+    "underline": true
+  },
+  "link_text": {
+    "color": "29",
+    "bold": true
+  },
+  "image": {
+    "color": "205",
+    "underline": true
+  },
+  "image_text": {
+    "color": "243",
+    "format": "Image: {{.text}} →"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "203",
+    "background_color": "254"
+  },
+  "code_block": {
+    "margin": 4,
+    "theme": "solarized-light"
+  },
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}


### PR DESCRIPTION
Source document is https://docs.google.com/document/d/1vOI4crZ55jxEXgTg0JRIghbU5R1SJmSTEB6K7VG3gio/edit and I've removed any sections that refer to currently unimplemented commands or functionality. We should add them back in as they get implemented.

`glamour` doesn't seem to render some of the bulleted lists quite as other renderers do when line breaks are involved:
<img width="628" height="169" alt="image" src="https://github.com/user-attachments/assets/34151f4a-2301-420c-b79f-5e8c6e3817a8" />

cf GitHub's rendering of same:
<img width="820" height="287" alt="image" src="https://github.com/user-attachments/assets/57011280-629e-46cb-af48-b22df38d4b74" />

This looks like https://github.com/charmbracelet/glamour/issues/167 to me (there are a number of similar issues there).

Resolves #41.