### PR TITLE
Add avail command

### DIFF
--- a/flight-desktop/main.go
+++ b/flight-desktop/main.go
@@ -93,6 +93,7 @@ func main() {
 			listSessionsCommand(),
 			killSessionCommand(),
 			showSessionCommand(),
+			typeAvailCommand(),
 		},
 	}
 

--- a/flight-desktop/main.go
+++ b/flight-desktop/main.go
@@ -89,11 +89,11 @@ func main() {
 			},
 		},
 		Commands: []*cli.Command{
+			typeAvailCommand(),
 			startSessionCommand(),
 			listSessionsCommand(),
-			killSessionCommand(),
 			showSessionCommand(),
-			typeAvailCommand(),
+			killSessionCommand(),
 		},
 	}
 

--- a/flight-desktop/main.go
+++ b/flight-desktop/main.go
@@ -89,7 +89,7 @@ func main() {
 			},
 		},
 		Commands: []*cli.Command{
-			startCommand(),
+			startSessionCommand(),
 			listSessionsCommand(),
 			killSessionCommand(),
 			showSessionCommand(),

--- a/flight-desktop/session_kill.go
+++ b/flight-desktop/session_kill.go
@@ -14,6 +14,7 @@ func killSessionCommand() *cli.Command {
 		Name:        "kill",
 		Usage:       "Terminate an interactive desktop session",
 		Description: wordwrap.String(fmt.Sprintf("Instruct an active interactive desktop session to terminate.\n\nThe <id> parameter should specify the session identity, use '%s list' to see a list of your sessions.", progName), 80),
+		Category:    "Sessions",
 		Arguments: []cli.Argument{
 			&cli.StringArg{Name: "id", UsageText: "<id>"},
 		},

--- a/flight-desktop/session_list.go
+++ b/flight-desktop/session_list.go
@@ -15,6 +15,7 @@ func listSessionsCommand() *cli.Command {
 		Name:        "list",
 		Usage:       "List interactive desktop sessions",
 		Description: wordwrap.String("Display all known desktop sessions and their states.", 80),
+		Category:    "Sessions",
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			sessions, err := loadAllSessions()
 			if err != nil {

--- a/flight-desktop/session_show.go
+++ b/flight-desktop/session_show.go
@@ -13,6 +13,7 @@ func showSessionCommand() *cli.Command {
 		Name:        "show",
 		Usage:       "Show information about a desktop session",
 		Description: wordwrap.String("Display the connection information for a desktop session.", maxTextWidth),
+		Category:    "Sessions",
 		Arguments: []cli.Argument{
 			&cli.StringArg{Name: "id", UsageText: "<id>"},
 		},

--- a/flight-desktop/session_start.go
+++ b/flight-desktop/session_start.go
@@ -21,6 +21,7 @@ func startSessionCommand() *cli.Command {
 		Name:        "start",
 		Usage:       "Start an interactive desktop session",
 		Description: wordwrap.String("Start a new interactive desktop session and display details about the new session.\n\nAvailable desktop types can be shown using the 'avail' command.", maxTextWidth),
+		Category:    "Sessions",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "name",

--- a/flight-desktop/session_start.go
+++ b/flight-desktop/session_start.go
@@ -12,18 +12,11 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-var (
-	// TODO: Determine this dynamically by listing the correct directory
-	// (opt/flight/usr/lib/desktop/types/).
-	validTypes            = []string{"terminal", "gnome"}
-	validTypeNames string = strings.Join(validTypes, ", ")
-)
-
 func libexecPath(relpath string) string {
 	return filepath.Join(flightRoot, "usr", "libexec", "desktop", relpath)
 }
 
-func startCommand() *cli.Command {
+func startSessionCommand() *cli.Command {
 	return &cli.Command{
 		Name:        "start",
 		Usage:       "Start an interactive desktop session",
@@ -76,14 +69,21 @@ func startCommand() *cli.Command {
 
 func assertTypeValid(argName string, argIndex int) cli.BeforeFunc {
 	return func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-
-		event := cmd.Args().Get(argIndex)
-		if !slices.Contains(validTypes, event) {
+		availableTypes, err := loadAllTypes()
+		typeNames := make([]string, 0, len(availableTypes))
+		for _, typ := range availableTypes {
+			typeNames = append(typeNames, typ.ID)
+		}
+		if err != nil {
+			return ctx, err
+		}
+		typ := cmd.Args().Get(argIndex)
+		if !slices.Contains(typeNames, typ) {
 			return ctx, fmt.Errorf(
 				"Incorrect Usage: unknown %s '%s'. Valid values are %s.",
 				argName,
-				event,
-				validTypeNames,
+				typ,
+				strings.Join(typeNames, ", "),
 			)
 		}
 		return ctx, nil

--- a/flight-desktop/theme.go
+++ b/flight-desktop/theme.go
@@ -21,6 +21,7 @@ var (
 	paragraph = lipgloss.NewStyle().Margin(0, 1, 1, 1)
 	code      = lipgloss.NewStyle().Background(grey).Foreground(primary).Bold(true)
 	bullet    = lipgloss.NewStyle().PaddingLeft(1).PaddingRight(2).Bold(true)
+	hyperlink = lipgloss.NewStyle().Foreground(lipgloss.Cyan)
 
 	tableHeaderStyle  = lipgloss.NewStyle().Foreground(ctmOrange).Bold(true).Align(lipgloss.Center)
 	tableCellStyle    = lipgloss.NewStyle().Padding(0, 1)

--- a/flight-desktop/type.go
+++ b/flight-desktop/type.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"charm.land/log/v2"
+	"gopkg.in/yaml.v3"
+)
+
+func loadAllTypes() ([]*Type, error) {
+	glob := filepath.Join(flightRoot, "usr", "lib", "desktop", "types", "*", "metadata.yml")
+	log.Debug("Loading all desktop types", "glob", glob)
+	types := make([]*Type, 0)
+	matches, err := filepath.Glob(glob)
+	if err != nil {
+		return nil, fmt.Errorf("loading types: %w", err)
+	}
+	for _, match := range matches {
+		id := filepath.Base(filepath.Dir(match))
+		typ, err := loadType(id)
+		if err != nil {
+			log.Debug("Skipping bad type", "match", match, "err", err)
+			continue
+		}
+		types = append(types, typ)
+	}
+	return types, nil
+}
+
+func loadType(id string) (*Type, error) {
+	typ := &Type{ID: id}
+	log.Debug("Loading desktop type", "dir", typ.dir())
+	info, err := os.Stat(typ.dir())
+	if err != nil {
+		log.Debug("Error checking dir", "dir", typ.dir(), "err", err)
+		return typ, UnknownType{Type: id}
+	}
+	if !info.IsDir() {
+		log.Debug("Desktop type dir is not a directory", "dir", typ.dir())
+		return typ, UnknownType{Type: id}
+	}
+
+	data, err := os.ReadFile(typ.metadataFile())
+	if err != nil {
+		log.Debug("Reading desktop type metadata", "metadataFile", typ.metadataFile(), "err", err)
+		return typ, nil
+	}
+	err = yaml.Unmarshal(data, &typ)
+	if err != nil {
+		log.Debug("Loading desktop type metadata", "metadataFile", typ.metadataFile(), "err", err)
+		return typ, nil
+	}
+	return typ, nil
+}
+
+type Type struct {
+	ID      string
+	Name    string `yaml:"name"`
+	Summary string `yaml:"summary"`
+	URL     string `yaml:"url"`
+}
+
+func (t *Type) dir() string {
+	return filepath.Join(flightRoot, "usr", "lib", "desktop", "types", t.ID)
+}
+
+func (t *Type) metadataFile() string {
+	return filepath.Join(t.dir(), "metadata.yml")
+}

--- a/flight-desktop/type_avail.go
+++ b/flight-desktop/type_avail.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"charm.land/lipgloss/v2"
+	"charm.land/lipgloss/v2/table"
+	"github.com/muesli/reflow/wordwrap"
+	"github.com/urfave/cli/v3"
+)
+
+func typeAvailCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "avail",
+		Usage:       "Show available desktop types",
+		Description: wordwrap.String("Display a list of available desktop types.", maxTextWidth),
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			types, err := loadAllTypes()
+			if err != nil {
+				return err
+			}
+			if len(types) == 0 {
+				fmt.Println("No desktop types found.")
+				return nil
+			}
+			err = typesTable(types)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+}
+
+func typesTable(types []*Type) error {
+	namecolWidth := 8
+
+	t := table.New().
+		Border(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(ctmOrange)).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			var style lipgloss.Style
+			switch {
+			case row == table.HeaderRow:
+				return tableHeaderStyle
+			case row%2 == 0:
+				style = tableEvenRowStyle
+			default:
+				style = tableOddRowStyle
+			}
+			switch col {
+			case 0:
+				return style.Width(namecolWidth)
+			}
+			return style
+		}).
+		Width(termWidth)
+	t.Headers("Name", "Summary")
+	for _, typ := range types {
+		namecolWidth = max(namecolWidth, len(typ.Name)+2)
+		summary := lipgloss.JoinVertical(
+			lipgloss.Left,
+			typ.Summary,
+			lipgloss.JoinHorizontal(
+				lipgloss.Top,
+				lipgloss.NewStyle().MarginRight(1).Render(">"),
+				hyperlink.MarginBottom(1).Hyperlink(typ.URL).Render(typ.URL),
+			),
+		)
+		t.Row(typ.Name, summary)
+	}
+	_, err := lipgloss.Println(t)
+	return err
+}
+
+type UnknownType struct {
+	Type string
+}
+
+func (ut UnknownType) Error() string {
+	return fmt.Sprintf("Unknown desktop type: %s", ut.Type)
+}

--- a/flight-desktop/type_avail.go
+++ b/flight-desktop/type_avail.go
@@ -15,6 +15,7 @@ func typeAvailCommand() *cli.Command {
 		Name:        "avail",
 		Usage:       "Show available desktop types",
 		Description: wordwrap.String("Display a list of available desktop types.", maxTextWidth),
+		Category:    "Desktop types",
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			types, err := loadAllTypes()
 			if err != nil {


### PR DESCRIPTION
This PR adds a `flight desktop avail` command; removes the hardcoding of available session types from the start command; and categorises the commands in the help output.

<img width="928" height="200" alt="image" src="https://github.com/user-attachments/assets/e3707188-9710-4943-bacd-f78b4e3cbc33" />

<img width="928" height="359" alt="image" src="https://github.com/user-attachments/assets/089dcb4c-c4a1-4fc5-819d-100facd19b01" />

Resolves #48 