### PR TITLE
Check for VNC server process rather than assume

### DIFF
--- a/flight-desktop/session.go
+++ b/flight-desktop/session.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"charm.land/log/v2"
@@ -26,6 +27,7 @@ var (
 	New    sessionState = "new"
 	Active sessionState = "active"
 	Broken sessionState = "broken"
+	Exited sessionState = "exited"
 )
 
 type Session struct {
@@ -85,6 +87,9 @@ func loadSession(id string) (*Session, error) {
 		log.Debug("Loading session metadata", "metadataFile", session.metadataFile(), "err", err)
 		session.SessionState = Broken
 		return session, nil
+	}
+	if !session.isActive() {
+		session.SessionState = Exited
 	}
 	return session, nil
 }
@@ -244,6 +249,26 @@ func (s *Session) sessionScript() string {
 
 func (s *Session) metadataFile() string {
 	return filepath.Join(s.sessionDir(), "metadata.yml")
+}
+
+func (s *Session) isActive() bool {
+	b, err := os.ReadFile(s.Metadata.Pidfile)
+	if err != nil {
+		log.Debug("Unable to read", "pidfile", s.Metadata.Pidfile, "err", err)
+		return false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil {
+		log.Debug("Unable to parse", "pidfile", s.Metadata.Pidfile, "err", err)
+		return false
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		log.Debug("Unable to find process", "pid", pid, "err", err)
+		return false
+	}
+	err = p.Signal(syscall.Signal(0))
+	return err == nil
 }
 
 func (s *Session) startVNC(ctx context.Context, dir string) error {

--- a/flight-desktop/session_details.go
+++ b/flight-desktop/session_details.go
@@ -35,6 +35,7 @@ func sessionInfo(session *Session) {
 			dt.Render("Name"),
 			dt.Render("Type"),
 			dt.Render("Screen size"),
+			dt.Render("State"),
 			dt.Render("Started at"),
 		),
 		lipgloss.JoinVertical(
@@ -42,6 +43,7 @@ func sessionInfo(session *Session) {
 			dd.Render(session.Name),
 			dd.Render(session.SessionType),
 			dd.Render(session.Geometry),
+			dd.Render(string(session.SessionState)),
 			dd.Render(session.CreatedAt.Format(time.RFC822)),
 		),
 	)
@@ -96,11 +98,18 @@ func connectionInfo(session *Session) {
 		subheader.Render("3. Need Help?"),
 		lipgloss.JoinHorizontal(
 			lipgloss.Top,
-			paragraph.Render("For more details on how to connect, run:"),
+			paragraph.MarginBottom(0).Render("For more details on how to connect, run:"),
 			code.Render("flight howto show flight-desktop"),
 		),
-		header.MarginTop(0).Render("Manage this session"),
-		paragraph.PaddingBottom(0).Render("To view details or stop this session later, you will need the Session ID:"),
+	)
+	lipgloss.Println(out)
+}
+
+func managementInfo(session *Session) {
+	out := lipgloss.JoinVertical(
+		lipgloss.Left,
+		header.Render("Manage this session"),
+		paragraph.PaddingBottom(0).Render("To view details or stop this session, you will need the Session ID:"),
 		code.Margin(0, 0, 1, 1).Render(session.ID),
 		paragraph.Render("(Tip: Run 'flight desktop --help' to see management commands)"),
 	)

--- a/flight-desktop/session_show.go
+++ b/flight-desktop/session_show.go
@@ -28,7 +28,10 @@ func showSessionCommand() *cli.Command {
 				return err
 			}
 			sessionInfo(session)
-			connectionInfo(session)
+			if session.SessionState == Active {
+				connectionInfo(session)
+			}
+			managementInfo(session)
 			return nil
 		},
 	}

--- a/flight-desktop/session_start.go
+++ b/flight-desktop/session_start.go
@@ -70,6 +70,7 @@ func startSessionCommand() *cli.Command {
 			fmt.Println()
 			sessionStarted(&session)
 			connectionInfo(&session)
+			managementInfo(&session)
 			return nil
 		},
 	}


### PR DESCRIPTION
When a session is loaded, we check if the session's pidfile points to an active process, if it does, we consider the session to be active.  If there are any errors, we consider the session to be exited.

The show command includes the session's state and no longer displays the connection info for inactive sessions.

<img width="804" height="857" alt="image" src="https://github.com/user-attachments/assets/ee097c3c-5de8-4521-849d-856e7fbd6b9b" />


Refs #36 