### PR TITLE
Better handle `list` column widths

### DIFF
--- a/flight-desktop/session_list.go
+++ b/flight-desktop/session_list.go
@@ -35,6 +35,12 @@ func listSessionsCommand() *cli.Command {
 }
 
 func sessionsTable(sessions []*Session) error {
+	namecolWidth := 8
+	maxNamecolWidth := 20
+	typecolWidth := 8
+	connectioncolWidth := 8
+	passwordcolWidth := 10
+
 	t := table.New().
 		Border(lipgloss.NormalBorder()).
 		BorderStyle(lipgloss.NewStyle().Foreground(ctmOrange)).
@@ -48,15 +54,36 @@ func sessionsTable(sessions []*Session) error {
 			default:
 				style = tableOddRowStyle
 			}
+			switch col {
+			case 0:
+				return style.Width(namecolWidth)
+			case 1:
+				return style.Width(typecolWidth)
+			case 2:
+				return style.MaxWidth(connectioncolWidth)
+			case 3:
+				return style.Width(passwordcolWidth)
+			case 4:
+				return style.Width(8)
+			case 5:
+				return style.MaxWidth(39)
+			}
 			return style
 		}).
 		Width(termWidth)
 	t.Headers("Name", "Type", "Connection string", "Password", "State", "ID")
 	for _, s := range sessions {
+		connectionString := s.PrimaryConnectionString()
+		namecolWidth = min(max(namecolWidth, len(s.Name)+2), maxNamecolWidth)
+		namecolWidth = max(namecolWidth, len(s.Name)+2)
+		typecolWidth = max(typecolWidth, len(s.SessionType)+2)
+		connectioncolWidth = max(connectioncolWidth, len(connectionString)+2)
+		passwordcolWidth = max(passwordcolWidth, len(s.Password)+2)
+
 		t.Row(
 			s.Name,
 			s.SessionType,
-			s.PrimaryConnectionString(),
+			connectionString,
 			s.Password,
 			string(s.SessionState),
 			s.ID,


### PR DESCRIPTION
The primary goal is to ensure that the table is no wider than the width of the terminal, otherwise we "lose" the ID and cannot copy paste from the list output to show or kill a session.

To achieve this there needs to be some flexibility in the column widths, so some have a width set whilst others have a max width.  After a small amount of playing with this seems the best compromise.

On a wide terminal (130 columns):

<img width="918" height="532" alt="image" src="https://github.com/user-attachments/assets/6800fa4c-b784-458c-a40f-2fb8731a691f" />

On a "standard" terminal (80 columns):

<img width="580" height="798" alt="image" src="https://github.com/user-attachments/assets/fd8e96a9-7631-4152-a96f-358857191712" />

It probably doesn't work below 80 columns :man_shrugging:.

We could probably do better by examining the width of the terminal, but that seems like a lot of work right now.  If we use session names as the session IDs (https://github.com/concertim/flight-user-suite/issues/46#issuecomment-4164363028), we'll have one less column to worry about, which might help.  Or just shorter IDs in general.