### PR TITLE
Disable all tools except `flight-howto` in distribution.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ $(MODULES):
 
 $(DIST): $(MODULES)
 	rsync -rlptgo $(foreach module,$(MODULES),$(module)/dist/) $(DIST)/
+# Disable all tools by default except flight-howto
+	chmod 0444 $(DIST)/opt/flight/usr/lib/flight-core/*
+	chmod 0555 $(DIST)/opt/flight/usr/lib/flight-core/flight-howto
 
 $(TARFILE): $(DIST)
 	tar czf $@ --owner=root:0 --group=root:0 -C $(DIST) .

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ $(DIST): $(MODULES)
 # Disable all tools by default except flight-howto
 	chmod 0444 $(DIST)/opt/flight/usr/lib/flight-core/*
 	chmod 0555 $(DIST)/opt/flight/usr/lib/flight-core/flight-howto
+# Note: if we ever want default-enabled tools that have documentation we will
+# also need to symlink the docs into
+# $(DIST)/opt/flight/usr/share/docs/howtos-enabled here.
 
 $(TARFILE): $(DIST)
 	tar czf $@ --owner=root:0 --group=root:0 -C $(DIST) .


### PR DESCRIPTION
This seemed like the best place to do it...

`flight-howto` doesn't itself have any howto documents related to it, or otherwise we'd also need to worry about symlinking those into the appropriate directory.

Resolves #25.