### PR TITLE
Add doctor command to perform system health check

### DIFF
--- a/flight-desktop/config.go
+++ b/flight-desktop/config.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+type config struct {
+	Dependencies []dependency `yaml:"dependencies"`
+}
+
+type dependency struct {
+	Type  string   `yaml:"type"`
+	Paths []string `yaml:"paths"`
+}
+
+func loadConfig() (*config, error) {
+	path := filepath.Join(flightRoot, "etc", "desktop.yml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("loading config: %w", err)
+	}
+	var config config
+	err = yaml.Unmarshal(data, &config)
+	if err != nil {
+		return nil, fmt.Errorf("loading config from %s: %w", path, err)
+	}
+	return &config, nil
+}

--- a/flight-desktop/doctor.go
+++ b/flight-desktop/doctor.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/muesli/reflow/wordwrap"
+	"github.com/urfave/cli/v3"
+	"github.com/yarlson/pin"
+)
+
+func doctorCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "doctor",
+		Usage:       "System health check",
+		Description: wordwrap.String("Perform a health check on the system to check that all dependencies are present.", maxTextWidth),
+		Category:    "Desktop types",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			config, err := loadConfig()
+			if err != nil {
+				return err
+			}
+			allOK := true
+			fmt.Println()
+			p := pin.New("Checking core dependencies...",
+				pin.WithSpinnerColor(pin.ColorCyan),
+				pin.WithTextColor(pin.ColorGreen),
+				pin.WithDoneSymbol('\u2705'),
+				pin.WithFailSymbol('\u274c'),
+				pin.WithFailColor(pin.ColorRed),
+			)
+			cancel := p.Start(ctx)
+			defer cancel()
+			checkResults, ok := runDoctor(config.Dependencies)
+			<-time.After(1 * time.Second)
+			if ok {
+				p.Stop("Core dependencies")
+			} else {
+				p.Fail("Missing core dependencies")
+				allOK = false
+			}
+			printCheckResults(checkResults)
+
+			types, err := loadAllTypes()
+			if err != nil {
+				fmt.Printf("\u274c Checking dependencies for desktop types failed: %s", err.Error())
+				allOK = false
+			} else {
+				for _, typ := range types {
+					deps, err := typ.Dependencies()
+					if err != nil {
+						fmt.Printf("\u274c Checking dependencies for %s desktop type failed: %s", typ.ID, err.Error())
+						allOK = false
+						continue
+					}
+					fmt.Println()
+					p := pin.New(fmt.Sprintf("Checking dependencies for %s.. desktop type.", typ.ID),
+						pin.WithSpinnerColor(pin.ColorCyan),
+						pin.WithTextColor(pin.ColorGreen),
+						pin.WithDoneSymbol('\u2705'),
+						pin.WithFailSymbol('\u274c'),
+						pin.WithFailColor(pin.ColorRed),
+					)
+					cancel := p.Start(ctx)
+					defer cancel()
+					checkResults, ok := runDoctor(deps)
+					<-time.After(1 * time.Second)
+					if ok {
+						p.Stop(fmt.Sprintf("Dependencies for %s desktop type", typ.ID))
+					} else {
+						p.Fail(fmt.Sprintf("Missing dependencies for %s desktop type", typ.ID))
+						allOK = false
+					}
+					printCheckResults(checkResults)
+				}
+			}
+			if allOK {
+				return nil
+			} else {
+				fmt.Println()
+				return cli.Exit("Required dependencies missing", 1)
+			}
+		},
+	}
+}
+
+type checkResult struct {
+	dependency dependency
+	found      bool
+	foundAt    string
+	err        error
+}
+
+func runDoctor(dependencies []dependency) ([]checkResult, bool) {
+	checkResults := make([]checkResult, 0)
+	allOK := true
+	for _, dep := range dependencies {
+		switch dep.Type {
+		case "exe":
+			result := checkExeAvailable(dep)
+			if result.err != nil {
+				allOK = false
+			}
+			checkResults = append(checkResults, result)
+		case "dir":
+			result := checkDirNonEmpty(dep)
+			if result.err != nil {
+				allOK = false
+			}
+			checkResults = append(checkResults, result)
+		}
+	}
+	return checkResults, allOK
+}
+
+func printCheckResults(checkResults []checkResult) {
+	depParts := make([]string, 0, len(checkResults))
+	resultParts := make([]string, 0, len(checkResults))
+	for _, result := range checkResults {
+		tick := " > \u2705 "
+		outcome := result.foundAt
+		if !result.found {
+			tick = " > \u274c "
+			outcome = result.err.Error()
+		}
+		formattedPath := strings.Join(result.dependency.Paths, "\n")
+		depPart := lipgloss.JoinHorizontal(lipgloss.Top, tick, formattedPath)
+		resultPart := lipgloss.JoinHorizontal(lipgloss.Top, " : ", outcome)
+		depParts = append(depParts, depPart)
+		resultParts = append(resultParts, resultPart)
+	}
+
+	out := lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		lipgloss.JoinVertical(lipgloss.Left, depParts...),
+		lipgloss.JoinVertical(lipgloss.Left, resultParts...),
+	)
+	lipgloss.Println("")
+	lipgloss.Println(out)
+}
+
+func checkExeAvailable(dep dependency) checkResult {
+	var errs error
+	for _, path := range dep.Paths {
+		location, err := exec.LookPath(path)
+		if err == nil {
+			return checkResult{
+				dependency: dep,
+				found:      true,
+				foundAt:    location,
+				err:        nil,
+			}
+		}
+		errs = errors.Join(errs, err)
+	}
+	return checkResult{
+		dependency: dep,
+		found:      false,
+		foundAt:    "",
+		err:        errs,
+	}
+}
+
+func checkDirNonEmpty(dep dependency) checkResult {
+	foundNonEmtpy := false
+	var foundAt string
+
+	for _, dir := range dep.Paths {
+		entries, _ := os.ReadDir(dir)
+		if len(entries) > 0 {
+			foundAt = dir
+			foundNonEmtpy = true
+			break
+		}
+	}
+	var err error
+	if !foundNonEmtpy {
+		err = errors.New("non-empty directory not-found")
+	}
+	return checkResult{
+		dependency: dep,
+		found:      foundNonEmtpy,
+		foundAt:    foundAt,
+		err:        err,
+	}
+}

--- a/flight-desktop/main.go
+++ b/flight-desktop/main.go
@@ -86,6 +86,7 @@ func main() {
 		},
 		Commands: []*cli.Command{
 			typeAvailCommand(),
+			doctorCommand(),
 			startSessionCommand(),
 			listSessionsCommand(),
 			showSessionCommand(),

--- a/flight-desktop/opt/flight/etc/desktop.yml
+++ b/flight-desktop/opt/flight/etc/desktop.yml
@@ -1,0 +1,20 @@
+dependencies:
+  - type: exe
+    paths:
+      - "/usr/bin/Xvnc"
+
+  - type: exe
+    paths:
+      - "xauth"
+
+  - type: exe
+    paths:
+      - "/usr/bin/vncpasswd"
+
+  - type: exe
+    paths:
+      - "vncconfig"
+
+  - type: exe
+    paths:
+      - "curl"

--- a/flight-desktop/opt/flight/usr/lib/desktop/types/gnome/dependencies.yml
+++ b/flight-desktop/opt/flight/usr/lib/desktop/types/gnome/dependencies.yml
@@ -1,0 +1,22 @@
+- type: exe
+  paths:
+    - "xrdb"
+
+- type: exe
+  paths:
+    - "gconftool-2"
+
+- type: exe
+  paths:
+    - "gnome-terminal"
+
+- type: exe
+  paths:
+    - "gnome-session"
+
+- type: dir
+  # Any one of these not being empty is good enough.
+  paths:
+    - "/usr/share/X11/fonts"
+    - "/usr/share/fonts"
+    - "/usr/share/fonts/X11"

--- a/flight-desktop/opt/flight/usr/lib/desktop/types/terminal/dependencies.yml
+++ b/flight-desktop/opt/flight/usr/lib/desktop/types/terminal/dependencies.yml
@@ -1,0 +1,7 @@
+- type: exe
+  paths:
+    - "xterm"
+
+- type: exe
+  paths:
+    - "xrdb"

--- a/flight-desktop/opt/flight/usr/share/doc/flight-desktop/flight-desktop.md
+++ b/flight-desktop/opt/flight/usr/share/doc/flight-desktop/flight-desktop.md
@@ -27,6 +27,14 @@ criteria:
 - The system, network and platform firewalls are configured to allow in a range
   of VNC ports (a range starting at `5901`)
 
+You will also need to ensure that certain dependencies are installed on your
+system. Flight desktop can provide a report highlighting any missing
+dependencies, by running:
+
+```bash
+flight desktop doctor
+```
+
 ## Desktop environment support
 
 Flight Desktop comes with support for running sessions in the following

--- a/flight-desktop/type.go
+++ b/flight-desktop/type.go
@@ -62,6 +62,20 @@ type Type struct {
 	URL     string `yaml:"url"`
 }
 
+func (t *Type) Dependencies() ([]dependency, error) {
+	path := filepath.Join(t.dir(), "dependencies.yml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("loading dependencies for %s: %w", t.ID, err)
+	}
+	var deps []dependency
+	err = yaml.Unmarshal(data, &deps)
+	if err != nil {
+		return nil, fmt.Errorf("loading config from %s: %w", path, err)
+	}
+	return deps, nil
+}
+
 func (t *Type) dir() string {
 	return filepath.Join(flightRoot, "usr", "lib", "desktop", "types", t.ID)
 }


### PR DESCRIPTION
Flight desktop, itself, and the desktop types are able to specify any dependencies they have. It is expected that desktop, itself will list core dependencies that are common to all desktop types, and the individual types list only their own dependencies.

There are two types of dependency, executables and directories.

An executable can be specified either as an absolute path, or as a name to be lookedup from PATH. In either case, the file must be found and must be executable.

A directory must exist and be non-empty to satisfy the dependency.

In both cases a list of paths any one of which can satisfy the dependency is provided.

Flight desktop does so in its new configuration file `${FLIGHT_ROOT}/etc/desktop.yml`.

The desktop types do so in their new dependency file `${FLIGHT_ROOT}/usr/lib/desktop/types/<type>/dependencies.yml`.


[Screencast from 01-04-26 16:06:11.webm](https://github.com/user-attachments/assets/1f083326-1d25-4b32-9f3b-50bd2e1f51f0)


Resolves #57