### PR TITLE
`.md` suffix is optional when using `flight howto show`.

### DIFF
--- a/flight-howto/main.go
+++ b/flight-howto/main.go
@@ -96,6 +96,11 @@ func list(ctx context.Context, cmd *cli.Command) error {
 func show(ctx context.Context, cmd *cli.Command) error {
 	howtoName := cmd.Args().First()
 	fullPath := filepath.Join(howtoDir, howtoName)
+
+	if !strings.HasSuffix(fullPath, ".md") {
+		fullPath = fullPath + ".md"
+	}
+
 	markdown, err := os.ReadFile(fullPath)
 	if err != nil {
 		if pathError, ok := errors.AsType[*fs.PathError](err); ok {
@@ -143,7 +148,8 @@ func PrintDirContents(dirPath string) error {
 
 			ext := filepath.Ext(relPath)
 			if ext == ".md" {
-				fmt.Println(relPath)
+				name, _ = strings.CutSuffix(relPath, ".md")
+				fmt.Println(name)
 			}
 		}
 	}


### PR DESCRIPTION
Also hide this extension when using `flight howto list` - it's just visual noise since all the howtos are Markdown documents by definition.

Resolves #49.