### PR TITLE
Run `doctor` checks before launching a desktop session.

### DIFF
--- a/flight-desktop/session_start.go
+++ b/flight-desktop/session_start.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/muesli/reflow/wordwrap"
@@ -104,6 +105,9 @@ func checkDependencies(ctx context.Context, sessionType string) (bool, error) {
 	p := createPin("Checking system dependencies...")
 	cancel := p.Start(ctx)
 	defer cancel()
+
+	// Add a small delay to stop the spinner from flickering
+	<-time.After(1 * time.Second)
 
 	globalResults, globalDepsOK := runDoctor(requiredDependencies(config.Dependencies))
 

--- a/flight-desktop/session_start.go
+++ b/flight-desktop/session_start.go
@@ -44,13 +44,13 @@ func startSessionCommand() *cli.Command {
 			sessionType := cmd.StringArg("type")
 			fmt.Printf("Starting a '%s' desktop session:\n\n", sessionType)
 
-			p := pin.New("Starting session...",
-				pin.WithSpinnerColor(pin.ColorCyan),
-				pin.WithTextColor(pin.ColorGreen),
-				pin.WithDoneSymbol('\u2705'),
-				pin.WithFailSymbol('\u274c'),
-				pin.WithFailColor(pin.ColorRed),
-			)
+			depsOK, err := checkDependencies(ctx, sessionType)
+
+			if !depsOK {
+				return err
+			}
+
+			p := createPin("Starting session...")
 			cancel := p.Start(ctx)
 			defer cancel()
 
@@ -61,7 +61,7 @@ func startSessionCommand() *cli.Command {
 				Name:         cmd.String("name"),
 				Geometry:     cmd.String("geometry"),
 			}
-			err := session.Start(ctx)
+			err = session.Start(ctx)
 			if err != nil {
 				p.Fail("Starting session failed")
 				return fmt.Errorf("starting session: %w", err)
@@ -97,4 +97,53 @@ func assertTypeValid(argName string, argIndex int) cli.BeforeFunc {
 		}
 		return ctx, nil
 	}
+}
+
+func checkDependencies(ctx context.Context, sessionType string) (bool, error) {
+	config, err := loadConfig()
+	p := createPin("Checking system dependencies...")
+	cancel := p.Start(ctx)
+	defer cancel()
+
+	globalResults, globalDepsOK := runDoctor(config.Dependencies)
+
+	if !globalDepsOK {
+		p.Fail("Missing critical dependencies")
+		printCheckResults(globalResults)
+		return false, nil
+	}
+
+	sessionTypeDef, err := loadType(sessionType)
+
+	if err != nil {
+		return false, err
+	}
+
+	err = sessionTypeDef.loadDependencies()
+	if err != nil {
+		return false, err
+	}
+
+	typeResults, typeDepsOK := runDoctor(sessionTypeDef.dependencies)
+
+	if !typeDepsOK {
+		p.Fail(fmt.Sprintf("Missing required dependencies for %s desktop type", sessionType))
+		printCheckResults(typeResults)
+		return false, err
+	}
+
+	p.Stop("Dependencies OK")
+
+	return true, err
+}
+
+func createPin(text string) *pin.Pin {
+	return pin.New(
+		text,
+		pin.WithSpinnerColor(pin.ColorCyan),
+		pin.WithTextColor(pin.ColorGreen),
+		pin.WithDoneSymbol('\u2705'),
+		pin.WithFailSymbol('\u274c'),
+		pin.WithFailColor(pin.ColorRed),
+	)
 }

--- a/flight-desktop/session_start.go
+++ b/flight-desktop/session_start.go
@@ -105,7 +105,7 @@ func checkDependencies(ctx context.Context, sessionType string) (bool, error) {
 	cancel := p.Start(ctx)
 	defer cancel()
 
-	globalResults, globalDepsOK := runDoctor(config.Dependencies)
+	globalResults, globalDepsOK := runDoctor(requiredDependencies(config.Dependencies))
 
 	if !globalDepsOK {
 		p.Fail("Missing critical dependencies")
@@ -124,7 +124,7 @@ func checkDependencies(ctx context.Context, sessionType string) (bool, error) {
 		return false, err
 	}
 
-	typeResults, typeDepsOK := runDoctor(sessionTypeDef.dependencies)
+	typeResults, typeDepsOK := runDoctor(requiredDependencies(sessionTypeDef.dependencies))
 
 	if !typeDepsOK {
 		p.Fail(fmt.Sprintf("Missing required dependencies for %s desktop type", sessionType))


### PR DESCRIPTION
This PR adds in a "checking dependencies" step before attempting to launch a desktop session.

If a dependency is missing, we report it:
<img width="603" height="120" alt="image" src="https://github.com/user-attachments/assets/c9396476-5230-4291-a388-1857b1e7c01b" />
(Note: since this screenshot was taken I've removed the backticks to be consistent with `flight desktop doctor`'s output)

We then abort without attempting to launch the session. Otherwise we report that everything is OK:
<img width="603" height="211" alt="image" src="https://github.com/user-attachments/assets/12188086-0cb8-4e8f-8d09-93facde35202" />

Resolves #62.