### PR TITLE
Improve session failure handling

### DIFF
--- a/flight-desktop/main.go
+++ b/flight-desktop/main.go
@@ -91,6 +91,7 @@ func main() {
 			listSessionsCommand(),
 			showSessionCommand(),
 			killSessionCommand(),
+			cleanSessionCommand(),
 		},
 	}
 

--- a/flight-desktop/opt/flight/usr/libexec/desktop/cleaner
+++ b/flight-desktop/opt/flight/usr/libexec/desktop/cleaner
@@ -1,0 +1,22 @@
+#!/bin/bash
+process_wait_for_pid() {
+    local pid
+    pid=$1
+    while [ -d /proc/$pid ]; do
+        sleep 5 &
+        # Wait for the backgrounded sleep to complete. Running the sleep in the
+        # background, allows this process to be responsive to any signals it
+        # receives.
+        wait $!
+    done
+}
+
+process_wait_for_pid $SESSION_VNC_PID
+
+for a in $SESSION_PIDS; do
+  kill $a
+done
+
+if [ -z "$FLIGHT_DESKTOP_DEBUG" ]; then
+  rm -rf $SESSION_DIR
+fi

--- a/flight-desktop/session.go
+++ b/flight-desktop/session.go
@@ -143,6 +143,9 @@ func (s *Session) Start(ctx context.Context) error {
 }
 
 func (s *Session) cleanup() {
+	if os.Getenv("FLIGHT_DESKTOP_DEBUG") != "" {
+		return
+	}
 	if err := s.RemoveSessionDir(); err != nil {
 		log.Debug("Failed to remove session dir", "err", err)
 	}
@@ -389,6 +392,9 @@ func (s *Session) startCleaner(ctx context.Context) error {
 		fmt.Sprintf("SESSION_VNC_PID=%s", pid),
 		"SESSION_PIDS=\"\"",
 		fmt.Sprintf("SESSION_DIR=%s", s.sessionDir()),
+	}
+	if os.Getenv("FLIGHT_DESKTOP_DEBUG") != "" {
+		cmd.Env = append(cmd.Env, "FLIGHT_DESKTOP_DEBUG=true")
 	}
 	cmd.Dir = "/"
 	err = cmd.Start()

--- a/flight-desktop/session.go
+++ b/flight-desktop/session.go
@@ -128,6 +128,12 @@ func (s *Session) Start(ctx context.Context) error {
 		s.cleanup()
 		return fmt.Errorf("staring VNC server: %w", err)
 	}
+	if err := s.startCleaner(ctx); err != nil {
+		// Don't return an error here, as we still want to save the session and
+		// recovering from this error is possible by manually running the clean
+		// command.
+		log.Debug("Failed to start cleaner script", "err", err)
+	}
 	s.SessionState = Active
 	err := s.Save()
 	if err != nil {
@@ -369,6 +375,26 @@ func (s *Session) parseVNCOutput(output []byte) error {
 		return err
 	}
 	s.Metadata = md
+	return nil
+}
+
+func (s *Session) startCleaner(ctx context.Context) error {
+	data, err := os.ReadFile(s.Metadata.Pidfile)
+	if err != nil {
+		return fmt.Errorf("reading pidfile: %w", err)
+	}
+	pid := strings.TrimSpace(string(data))
+	cmd := exec.CommandContext(ctx, libexecPath("cleaner"))
+	cmd.Env = []string{
+		fmt.Sprintf("SESSION_VNC_PID=%s", pid),
+		"SESSION_PIDS=\"\"",
+		fmt.Sprintf("SESSION_DIR=%s", s.sessionDir()),
+	}
+	cmd.Dir = "/"
+	err = cmd.Start()
+	if err != nil {
+		return fmt.Errorf("starting cleaner: %w", err)
+	}
 	return nil
 }
 

--- a/flight-desktop/session.go
+++ b/flight-desktop/session.go
@@ -117,17 +117,15 @@ func (s *Session) Start(ctx context.Context) error {
 		return err
 	}
 	if err := s.createPassword(); err != nil {
+		s.cleanup()
 		return err
 	}
 	if err := s.installSessionScript(); err != nil {
+		s.cleanup()
 		return err
 	}
 	if err := s.startVNC(ctx, xdg.Home); err != nil {
-		s.SessionState = Broken
-		saveErr := s.Save()
-		if saveErr != nil {
-			log.Debug("Failed to save failed session", "save.err", saveErr, "err", err)
-		}
+		s.cleanup()
 		return fmt.Errorf("staring VNC server: %w", err)
 	}
 	s.SessionState = Active
@@ -138,6 +136,12 @@ func (s *Session) Start(ctx context.Context) error {
 	return nil
 }
 
+func (s *Session) cleanup() {
+	if err := s.RemoveSessionDir(); err != nil {
+		log.Debug("Failed to remove session dir", "err", err)
+	}
+}
+
 func (s *Session) Save() error {
 	data, err := yaml.Marshal(&s)
 	if err != nil {
@@ -145,8 +149,7 @@ func (s *Session) Save() error {
 	}
 	metadataFile := s.metadataFile()
 	log.Debug("saving session", "file", metadataFile)
-	os.WriteFile(metadataFile, data, 0o600)
-	return nil
+	return os.WriteFile(metadataFile, data, 0o600)
 }
 
 func (s *Session) Kill(ctx context.Context) error {

--- a/flight-desktop/session_clean.go
+++ b/flight-desktop/session_clean.go
@@ -52,7 +52,7 @@ You can specify which sessions are cleaned by providing the optional <id> parame
 			timer := time.After(1 * time.Second)
 
 			var firstErr error
-			skippedStyle := lipgloss.NewStyle().Foreground(primary).MarginLeft(1)
+			skippedStyle := lipgloss.NewStyle().Foreground(lightDark(primary, cream)).MarginLeft(1)
 			cleanedStyle := lipgloss.NewStyle().Foreground(lipgloss.Green).MarginLeft(1)
 			failedStyle := lipgloss.NewStyle().Foreground(lipgloss.Red).MarginLeft(1)
 			cleaned := make([]*Session, 0)

--- a/flight-desktop/session_clean.go
+++ b/flight-desktop/session_clean.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/muesli/reflow/wordwrap"
+	"github.com/urfave/cli/v3"
+	"github.com/yarlson/pin"
+)
+
+func cleanSessionCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "clean",
+		Usage: "Clean up one or more exited desktop sessions",
+		Description: wordwrap.String(`Remove one or more desktop session directories for exited or broken desktop sessions.
+
+Depending on how cleanly desktop sessions exit, the session directory may be retained and require manual cleaning.  Desktops that are cleanly exited or manually terminated using the 'kill' command are automatically cleaned when the exit.
+
+You can specify which sessions are cleaned by providing the optional <id> parameter one or more times. If no <id>s are specified, data for all sessions that are marked as 'exited' or 'broken' will be removed.`, maxTextWidth),
+
+		Category: "Sessions",
+		Arguments: []cli.Argument{
+			&cli.StringArgs{Name: "id", UsageText: "[<id>...]", Min: 0, Max: -1},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			ids := cmd.StringArgs("id")
+			var sessions []*Session
+			if len(ids) == 0 {
+				var err error
+				sessions, err = loadAllSessions()
+				if err != nil {
+					return err
+				}
+			} else {
+				sessions = make([]*Session, 0, len(ids))
+				for _, id := range ids {
+					session, _ := loadSession(id)
+					sessions = append(sessions, session)
+				}
+			}
+			p := pin.New("Cleaning desktop sessions",
+				pin.WithSpinnerColor(pin.ColorCyan),
+				pin.WithTextColor(pin.ColorGreen),
+				pin.WithDoneSymbol('\u2705'),
+				pin.WithFailSymbol('\u274c'),
+				pin.WithFailColor(pin.ColorRed),
+			)
+			cancel := p.Start(ctx)
+			defer cancel()
+			timer := time.After(1 * time.Second)
+
+			var firstErr error
+			skippedStyle := lipgloss.NewStyle().Foreground(primary).MarginLeft(1)
+			cleanedStyle := lipgloss.NewStyle().Foreground(lipgloss.Green).MarginLeft(1)
+			failedStyle := lipgloss.NewStyle().Foreground(lipgloss.Red).MarginLeft(1)
+			cleaned := make([]*Session, 0)
+			failed := make([]*Session, 0)
+			skipped := make([]*Session, 0)
+
+			for _, session := range sessions {
+				if session.SessionState == Active {
+					skipped = append(skipped, session)
+				} else {
+					err := session.RemoveSessionDir()
+					if err != nil {
+						failed = append(failed, session)
+						if firstErr == nil {
+							firstErr = err
+						}
+					} else {
+						cleaned = append(cleaned, session)
+					}
+				}
+			}
+
+			<-timer
+
+			var out string
+			if len(cleaned) > 0 {
+				coloured := make([]string, 0, len(cleaned))
+				for _, session := range cleaned {
+					coloured = append(coloured, cleanedStyle.Render(session.ID))
+				}
+				out = lipgloss.JoinVertical(
+					lipgloss.Left,
+					append([]string{out, header.Render("Cleaned exited sessions")}, coloured...)...,
+				)
+			}
+			if len(failed) > 0 {
+				coloured := make([]string, 0, len(failed))
+				for _, session := range failed {
+					coloured = append(coloured, failedStyle.Render(session.ID))
+				}
+				out = lipgloss.JoinVertical(
+					lipgloss.Left,
+					append([]string{out, header.Render("Failed to clean")}, coloured...)...,
+				)
+			}
+			if len(skipped) > 0 {
+				coloured := make([]string, 0, len(skipped))
+				for _, session := range skipped {
+					coloured = append(coloured, skippedStyle.Render(session.ID))
+				}
+				out = lipgloss.JoinVertical(
+					lipgloss.Left,
+					append([]string{out, header.Render("Skipped active/remote sessions")}, coloured...)...,
+				)
+			}
+
+			if firstErr != nil {
+				p.Fail("Cleaning failed")
+			} else {
+				p.Stop("Cleaning complete")
+			}
+			lipgloss.Println(out)
+			return firstErr
+		},
+	}
+}

--- a/flight-desktop/session_clean.go
+++ b/flight-desktop/session_clean.go
@@ -81,7 +81,7 @@ You can specify which sessions are cleaned by providing the optional <id> parame
 			if len(cleaned) > 0 {
 				coloured := make([]string, 0, len(cleaned))
 				for _, session := range cleaned {
-					coloured = append(coloured, cleanedStyle.Render(session.ID))
+					coloured = append(coloured, cleanedStyle.Render(session.Name))
 				}
 				out = lipgloss.JoinVertical(
 					lipgloss.Left,
@@ -91,7 +91,7 @@ You can specify which sessions are cleaned by providing the optional <id> parame
 			if len(failed) > 0 {
 				coloured := make([]string, 0, len(failed))
 				for _, session := range failed {
-					coloured = append(coloured, failedStyle.Render(session.ID))
+					coloured = append(coloured, failedStyle.Render(session.Name))
 				}
 				out = lipgloss.JoinVertical(
 					lipgloss.Left,
@@ -101,7 +101,7 @@ You can specify which sessions are cleaned by providing the optional <id> parame
 			if len(skipped) > 0 {
 				coloured := make([]string, 0, len(skipped))
 				for _, session := range skipped {
-					coloured = append(coloured, skippedStyle.Render(session.ID))
+					coloured = append(coloured, skippedStyle.Render(session.Name))
 				}
 				out = lipgloss.JoinVertical(
 					lipgloss.Left,


### PR DESCRIPTION
This PR deals with the issue of empty directories being spammed if launching a script fails.  It does so in three ways:

* If we can detect a failure when launching the desktop session, we clean up the session directory.
* A "cleaner" script is launched after the VNC server. This script waits for the VNC server process and when that process exits, cleans up the session's session directory.
* Added a `clean` command that will remove the session directory for any `exited` or `broken` sessions.

NOTE: The clean command doesn't handle remote sessions correctly, as they don't exist yet.  Once added, the clean command will need to be updated to skip them too.

Resolves #65 