### PR TITLE
Add config commands to manage settings

### DIFF
--- a/flight-core/config_command.go
+++ b/flight-core/config_command.go
@@ -211,12 +211,16 @@ func saveConfig(key, value string, global bool) error {
 	for k, v := range config {
 		fmt.Fprintf(&b, "%s=%s\n", k, v)
 	}
-	return os.WriteFile(path, []byte(b.String()), 0o600)
+	if global {
+		return os.WriteFile(path, []byte(b.String()), 0o666)
+	} else {
+		return os.WriteFile(path, []byte(b.String()), 0o600)
+	}
 }
 
 func globalConfigPath() (string, error) {
 	name := filepath.Join("flight", "settings.config")
-	paths := xdg.ConfigDirs
+	paths := []string{"/etc/xdg"}
 	return configPath(name, paths)
 }
 
@@ -235,7 +239,7 @@ func configPath(name string, paths []string) (string, error) {
 		if exists(dir) {
 			return p, nil
 		}
-		if err := os.MkdirAll(dir, os.ModeDir|0o700); err == nil {
+		if err := os.MkdirAll(dir, os.ModeDir|0o777); err == nil {
 			return p, nil
 		}
 

--- a/flight-core/config_command.go
+++ b/flight-core/config_command.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"charm.land/log/v2"
+	"github.com/adrg/xdg"
+	"github.com/hashicorp/go-envparse"
+	"github.com/muesli/reflow/wordwrap"
+	"github.com/urfave/cli/v3"
+)
+
+var (
+	permittedKeys   = []string{"autostart"}
+	permittedValues = []string{"on", "off"}
+)
+
+func configCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "config",
+		Description: wordwrap.String("Manage Flight User Suite settings.", maxTextWidth),
+		Category:    "Configuration",
+		Commands: []*cli.Command{
+			{
+				Name:        "list",
+				Usage:       "List all Flight User Suite settings",
+				Description: wordwrap.String("List all Flight User Suite settings.", maxTextWidth),
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:  "global",
+						Usage: "only show global settings",
+					},
+				},
+				Action: configList,
+			},
+			{
+				Name:  "set",
+				Usage: "Set a Flight User Suite setting",
+				Description: wordwrap.String(`Set a Flight User Suite setting.
+
+Currently supported keys are 'autostart' which can be set to 'on' or 'off'.`, maxTextWidth),
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:  "global",
+						Usage: "change the setting for all users",
+					},
+				},
+				Arguments: []cli.Argument{
+					&cli.StringArg{Name: "key", UsageText: "<key>"},
+					&cli.StringArg{Name: "value", UsageText: "<value>"},
+				},
+				Action: configSet,
+			},
+			{
+				Name:  "get",
+				Usage: "Display a Flight User Suite setting",
+				Description: wordwrap.String(`Display a Flight User Suite setting.
+
+Currently supported keys are 'autostart'.`, maxTextWidth),
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:  "global",
+						Usage: "only get global settings",
+					},
+				},
+				Arguments: []cli.Argument{
+					&cli.StringArg{Name: "key", UsageText: "<key>"},
+				},
+				Action: configGet,
+			},
+		},
+	}
+}
+
+func configList(ctx context.Context, cmd *cli.Command) error {
+	var config map[string]string
+	if cmd.Bool("global") {
+		config = loadGlobalConfig()
+	} else {
+		config = loadMergedConfigs()
+	}
+	if len(config) == 0 {
+		fmt.Println("No config settings have been set.")
+	}
+	for k, v := range config {
+		k = strings.ToLower(strings.TrimPrefix(k, "FLIGHT_"))
+		fmt.Printf("%s=%s\n", k, v)
+	}
+	return nil
+}
+
+func configSet(ctx context.Context, cmd *cli.Command) error {
+	key := cmd.StringArg("key")
+	value := cmd.StringArg("value")
+	if !slices.Contains(permittedKeys, key) {
+		return cli.Exit(fmt.Sprintf("Setting '%s' is not permitted", key), 1)
+	}
+	if !slices.Contains(permittedValues, value) {
+		return cli.Exit(fmt.Sprintf("Value '%s' is not a valid value for '%s'", value, key), 1)
+	}
+	return saveConfig(key, value, cmd.Bool("global"))
+}
+
+func configGet(ctx context.Context, cmd *cli.Command) error {
+	var config map[string]string
+	if cmd.Bool("global") {
+		config = loadGlobalConfig()
+	} else {
+		config = loadMergedConfigs()
+	}
+	key := cmd.StringArg("key")
+	key = fmt.Sprintf("FLIGHT_%s", strings.ToUpper(key))
+	v, found := config[key]
+	if found {
+		fmt.Println(v)
+	} else {
+		return cli.Exit(fmt.Sprintf("Key '%s' is not known.\n", key), 1)
+	}
+	return nil
+}
+
+func loadMergedConfigs() map[string]string {
+	var globalConfig map[string]string
+	var userConfig map[string]string
+
+	globalConfig = loadGlobalConfig()
+	path, err := userConfigPath()
+	if err != nil {
+		log.Debug("Not merging user config", "path", path, "err", err)
+	} else {
+		userConfig, err = loadConfig(path)
+		if err != nil {
+			log.Debug("Not merging user config", "path", path, "err", err)
+		}
+	}
+
+	var config map[string]string
+	if globalConfig == nil {
+		config = make(map[string]string)
+	} else {
+		config = globalConfig
+	}
+	if userConfig != nil {
+		maps.Copy(config, userConfig)
+	}
+	return config
+}
+
+func loadGlobalConfig() map[string]string {
+	var globalConfig map[string]string
+
+	path, err := globalConfigPath()
+	if err != nil {
+		log.Debug("Not merging global config", "path", path, "err", err)
+		return nil
+	}
+	globalConfig, err = loadConfig(path)
+	if err != nil {
+		log.Debug("Not merging global config", "path", path, "err", err)
+	}
+	return globalConfig
+}
+
+func loadConfig(path string) (map[string]string, error) {
+	log.Debug("Loading config", "file", path)
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+	env, err := envparse.Parse(file)
+	if err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+	return env, nil
+}
+
+func saveConfig(key, value string, global bool) error {
+	var err error
+	var path string
+	var config map[string]string
+
+	if global {
+		path, err = globalConfigPath()
+		if err != nil {
+			return err
+		}
+	} else {
+		path, err = userConfigPath()
+		if err != nil {
+			return err
+		}
+	}
+	config, err = loadConfig(path)
+	if err != nil {
+		// This is fine.  We'll create the file below.
+		config = make(map[string]string)
+	}
+
+	key = fmt.Sprintf("FLIGHT_%s", strings.ToUpper(key))
+	config[key] = value
+	log.Debug("Saving config", "file", path, "config", config, "global", global)
+	var b strings.Builder
+	for k, v := range config {
+		fmt.Fprintf(&b, "%s=%s\n", k, v)
+	}
+	return os.WriteFile(path, []byte(b.String()), 0o600)
+}
+
+func globalConfigPath() (string, error) {
+	name := filepath.Join("flight", "settings.config")
+	paths := xdg.ConfigDirs
+	return configPath(name, paths)
+}
+
+func userConfigPath() (string, error) {
+	name := filepath.Join("flight", "settings.config")
+	paths := []string{xdg.ConfigHome}
+	return configPath(name, paths)
+}
+
+func configPath(name string, paths []string) (string, error) {
+	searchedPaths := make([]string, 0, len(paths))
+	for _, p := range paths {
+		p = filepath.Join(p, name)
+
+		dir := filepath.Dir(p)
+		if exists(dir) {
+			return p, nil
+		}
+		if err := os.MkdirAll(dir, os.ModeDir|0o700); err == nil {
+			return p, nil
+		}
+
+		searchedPaths = append(searchedPaths, dir)
+	}
+
+	return "", fmt.Errorf("could not create any of the following paths: %v",
+		searchedPaths)
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil || errors.Is(err, fs.ErrExist)
+}

--- a/flight-core/config_command.go
+++ b/flight-core/config_command.go
@@ -57,6 +57,7 @@ Currently supported keys are 'autostart' which can be set to 'on' or 'off'.`, ma
 					&cli.StringArg{Name: "key", UsageText: "<key>"},
 					&cli.StringArg{Name: "value", UsageText: "<value>"},
 				},
+				Before: assertArgPresent("key", "value"),
 				Action: configSet,
 			},
 			{
@@ -74,6 +75,7 @@ Currently supported keys are 'autostart'.`, maxTextWidth),
 				Arguments: []cli.Argument{
 					&cli.StringArg{Name: "key", UsageText: "<key>"},
 				},
+				Before: assertArgPresent("key"),
 				Action: configGet,
 			},
 		},
@@ -117,8 +119,7 @@ func configGet(ctx context.Context, cmd *cli.Command) error {
 		config = loadMergedConfigs()
 	}
 	key := cmd.StringArg("key")
-	key = fmt.Sprintf("FLIGHT_%s", strings.ToUpper(key))
-	v, found := config[key]
+	v, found := config[fmt.Sprintf("FLIGHT_%s", strings.ToUpper(key))]
 	if found {
 		fmt.Println(v)
 	} else {

--- a/flight-core/go.mod
+++ b/flight-core/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/cyucelen/marker v0.0.0-20220628090808-ec8d542c2d28
 	github.com/ergochat/readline v0.1.3
 	github.com/fatih/color v1.19.0
+	github.com/hashicorp/go-envparse v0.1.0
 	github.com/muesli/reflow v0.3.0
 	github.com/urfave/cli/v3 v3.7.0
 	golang.org/x/term v0.41.0

--- a/flight-core/go.sum
+++ b/flight-core/go.sum
@@ -34,6 +34,8 @@ github.com/go-logfmt/logfmt v0.6.1 h1:4hvbpePJKnIzH1B+8OR/JPbTx37NktoI9LE2QZBBkv
 github.com/go-logfmt/logfmt v0.6.1/go.mod h1:EV2pOAQoZaT1ZXZbqDl5hrymndi4SY9ED9/z6CO0XAk=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/hashicorp/go-envparse v0.1.0 h1:bE++6bhIsNCPLvgDZkYqo3nA+/PFI51pkrHdmPSDFPY=
+github.com/hashicorp/go-envparse v0.1.0/go.mod h1:OHheN1GoygLlAkTlXLXvAdnXdZxy8JUweQ1rAXx1xnc=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/flight-core/main.go
+++ b/flight-core/main.go
@@ -30,6 +30,8 @@ var (
 	hookDir         string
 	validEvents            = []string{"login", "activation"}
 	validEventNames string = strings.Join(validEvents, ", ")
+	termWidth       int    = 80
+	maxTextWidth    int    = 80
 )
 
 func init() {
@@ -39,16 +41,17 @@ func init() {
 	if root, ok := os.LookupEnv("FLIGHT_ROOT"); ok {
 		flightRoot = root
 	}
+	var err error
+	termWidth, _, err = term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		termWidth = 80
+	}
+	maxTextWidth = min(termWidth, 80)
 	toolDir = filepath.Join(flightRoot, "usr", "lib", "flight-core")
 	hookDir = filepath.Join(flightRoot, "usr", "lib", "hooks")
 }
 
 func main() {
-	termWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil {
-		termWidth = 80
-	}
-	maxTextWidth := min(termWidth, 80)
 	user, err := user.Current()
 	if err != nil {
 		log.Warn("Unable to determine user: not adding admin commands", "err", err)
@@ -105,6 +108,7 @@ func main() {
 				},
 				Action: runShell,
 			},
+			configCommand(),
 		},
 	}
 	if user != nil && user.Uid == "0" {

--- a/flight-starter/etc/profile.d/zz-flight-starter.sh
+++ b/flight-starter/etc/profile.d/zz-flight-starter.sh
@@ -3,6 +3,7 @@ if [ -z "$BASH_VERSION" ]; then
 fi
 
 export FLIGHT_ROOT=${FLIGHT_ROOT:-/opt/flight}
+FLIGHT_ROOT_ORIG=${FLIGHT_ROOT}
 
 if [ "${-#*u}" != "$-" ]; then
   set +u
@@ -15,6 +16,9 @@ for a in "${xdg_config[@]}"; do
     break
   fi
 done
+# Honour the FLIGHT_ROOT setting initially set.
+FLIGHT_ROOT=${FLIGHT_ROOT_ORIG}
+unset FLIGHT_ROOT_ORIG
 
 if [ "$(type -t flight-start)" != "function" ]; then
   flight-start() {
@@ -34,6 +38,27 @@ if [ -d "${FLIGHT_ROOT}"/usr/lib/hooks/login ]; then
   shopt -u nullglob
 fi
 unset hook
+
+# Load in any settings set by 'flight config set'. Allowing per-user settings
+# to override global settings.
+IFS=: read -a xdg_config <<< "${XDG_CONFIG_DIRS:-/etc/xdg}"
+for a in "${xdg_config[@]}"; do
+  if [ -e "${a}"/flight/settings.config ]; then
+    source "${a}"/flight/settings.config
+    break
+  fi
+done
+IFS=: read -a xdg_config <<< "${XDG_CONFIG_HOME:-$HOME/.config}"
+for a in "${xdg_config[@]}"; do
+  if [ -e "${a}"/flight/settings.config ]; then
+    source "${a}"/flight/settings.config
+    break
+  fi
+done
+
+if [ "${FLIGHT_AUTOSTART}" == "on" ] ; then
+	flight-start
+fi
 
 if [ "${_nounset_set}" == "true" ]; then
   set -u

--- a/flight-starter/etc/profile.d/zz-flight-starter.sh
+++ b/flight-starter/etc/profile.d/zz-flight-starter.sh
@@ -41,20 +41,14 @@ unset hook
 
 # Load in any settings set by 'flight config set'. Allowing per-user settings
 # to override global settings.
-IFS=: read -a xdg_config <<< "${XDG_CONFIG_DIRS:-/etc/xdg}"
-for a in "${xdg_config[@]}"; do
-  if [ -e "${a}"/flight/settings.config ]; then
-    source "${a}"/flight/settings.config
-    break
-  fi
-done
-IFS=: read -a xdg_config <<< "${XDG_CONFIG_HOME:-$HOME/.config}"
-for a in "${xdg_config[@]}"; do
-  if [ -e "${a}"/flight/settings.config ]; then
-    source "${a}"/flight/settings.config
-    break
-  fi
-done
+if [ -e "/etc/xdg/flight/settings.config ]; then
+  source "/etc/xdg/flight/settings.config
+  break
+fi
+if [ -e "${XDG_CONFIG_HOME:-$HOME/.config}"/flight/settings.config ]; then
+  source "${XDG_CONFIG_HOME:-$HOME/.config}"/flight/settings.config
+  break
+fi
 
 if [ "${FLIGHT_AUTOSTART}" == "on" ] ; then
 	flight-start


### PR DESCRIPTION
The config commands allow setting per-user and cluster-wide settings. The settings can be listed, set and got.  If the `--global` flag is provided only globally set, i.e., cluster-wide, settings are acted on. Otherwise, listing and setting merges cluster-wide and per-user settings and set sets the per-user setting.

The only setting that can currently be managed is `autostart`. If set the flight environment is automatically started when a login shell starts.

Example session:

```sh
$ cd dist
$ export FLIGHT_ROOT=`pwd`/opt/flight
$ XDG_CONFIG_DIRS=${XDG_CONFIG_DIRS}:`pwd`/../dist/etc/xdg
$ ./opt/flight/bin/flight config list
No config settings have been set.
$ ./opt/flight/bin/flight config set autostart on --global
$ ./opt/flight/bin/flight config list
autostart=on
$ source ./etc/profile.d/zz-flight-starter.sh 
                                   __ _ _       _     _  ==>
   ==>                            / _| (_)     | |   | |  ==>
  ==>   ___   _ __    ___  _ __  | |_| |_  __ _| |__ | |_  ==>
 ==>   / _ \ | '_ \  / _ \| '_ \ |  _| | |/ _` | '_ \| __|  ==>
==>   | (_) || |_) ||  __/| | | || | | | | (_| | | | | |_    ==>
 ==>   \___/ | .__/  \___||_| |_||_| |_|_|\__, |_| |_|\__|  ==>
  ==>        |_|                           __/ |           ==>
   ==>  Welcome to your cluster           |___/           ==>
    ==>  Flight User Suite v0.0.2-31-gbbec88d-dirty
     ==>  Based on Ubuntu 24.04.4 LTS

Flight environment is now active.
<flight> [ben@bens-laptop dist]$ flight-stop
Flight environment is now inactive.
$ ./opt/flight/bin/flight config set autostart off
$ ./opt/flight/bin/flight config list
autostart=off
$ ./opt/flight/bin/flight config list --global
autostart=on
$ source ./etc/profile.d/zz-flight-starter.sh 
$ flight-start
                                   __ _ _       _     _  ==>
   ==>                            / _| (_)     | |   | |  ==>
  ==>   ___   _ __    ___  _ __  | |_| |_  __ _| |__ | |_  ==>
 ==>   / _ \ | '_ \  / _ \| '_ \ |  _| | |/ _` | '_ \| __|  ==>
==>   | (_) || |_) ||  __/| | | || | | | | (_| | | | | |_    ==>
 ==>   \___/ | .__/  \___||_| |_||_| |_|_|\__, |_| |_|\__|  ==>
  ==>        |_|                           __/ |           ==>
   ==>  Welcome to your cluster           |___/           ==>
    ==>  Flight User Suite v0.0.2-31-gbbec88d-dirty
     ==>  Based on Ubuntu 24.04.4 LTS

Flight environment is now active.
<flight> [ben@bens-laptop dist]$ flight-stop
Flight environment is now inactive.
```