### PR TITLE
Augment `desktop avail` with dependency checks.

### DIFF
--- a/flight-desktop/type_avail.go
+++ b/flight-desktop/type_avail.go
@@ -6,6 +6,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/table"
+	"charm.land/log/v2"
 	"github.com/muesli/reflow/wordwrap"
 	"github.com/urfave/cli/v3"
 )
@@ -72,12 +73,18 @@ func typesTable(types []*Type) error {
 			),
 		)
 
-		typ.loadDependencies()
-		_, depsOK := runDoctor(requiredDependencies(typ.dependencies))
+		depsText := "\u2754 Unknown"
+		depsLoadError := typ.loadDependencies()
 
-		depsText := lipgloss.NewStyle().Foreground(lipgloss.Red).Render("\u274c Missing")
-		if depsOK {
-			depsText = lipgloss.NewStyle().Foreground(lipgloss.Green).Render("\u2705 OK")
+		if depsLoadError == nil {
+			_, depsOK := runDoctor(requiredDependencies(typ.dependencies))
+
+			depsText = lipgloss.NewStyle().Foreground(lipgloss.Red).Render("\u274c Missing")
+			if depsOK {
+				depsText = lipgloss.NewStyle().Foreground(lipgloss.Green).Render("\u2705 OK")
+			}
+		} else {
+			log.Debug("While loading dependencies for type", "type", typ.ID, "err", depsLoadError)
 		}
 
 		t.Row(typ.ID, summary, depsText)

--- a/flight-desktop/type_avail.go
+++ b/flight-desktop/type_avail.go
@@ -53,11 +53,13 @@ func typesTable(types []*Type) error {
 			switch col {
 			case 0:
 				return style.Width(namecolWidth)
+			case 2:
+				return style.Width(15)
 			}
 			return style
 		}).
 		Width(termWidth)
-	t.Headers("Name", "Summary")
+	t.Headers("Name", "Summary", "Dependencies")
 	for _, typ := range types {
 		namecolWidth = max(namecolWidth, len(typ.ID)+2)
 		summary := lipgloss.JoinVertical(
@@ -69,7 +71,16 @@ func typesTable(types []*Type) error {
 				hyperlink.MarginBottom(1).Hyperlink(typ.URL).Render(typ.URL),
 			),
 		)
-		t.Row(typ.ID, summary)
+
+		typ.loadDependencies()
+		_, depsOK := runDoctor(requiredDependencies(typ.dependencies))
+
+		depsText := lipgloss.NewStyle().Foreground(lipgloss.Red).Render("\u274c Missing")
+		if depsOK {
+			depsText = lipgloss.NewStyle().Foreground(lipgloss.Green).Render("\u2705 OK")
+		}
+
+		t.Row(typ.ID, summary, depsText)
 	}
 	_, err := lipgloss.Println(t)
 	return err


### PR DESCRIPTION
This PR adds an additional column to the table output by `flight desktop avail`, showing if dependencies of each available type are available or not.

<img width="1913" height="215" alt="image" src="https://github.com/user-attachments/assets/a6029d4a-2381-4a05-bb05-e24589346c3a" />


Resolves #76.