### PR TITLE
Add support for remote sessions

### DIFF
--- a/flight-desktop/session.go
+++ b/flight-desktop/session.go
@@ -44,16 +44,18 @@ var (
 	Active sessionState = "active"
 	Broken sessionState = "broken"
 	Exited sessionState = "exited"
+	Remote sessionState = "remote"
 )
 
 type Session struct {
-	Name         string
-	SessionType  string          `yaml:"session_type"`
-	Password     string          `yaml:"password"`
-	SessionState sessionState    `yaml:"state"`
-	Geometry     string          `yaml:"geometry"`
-	CreatedAt    time.Time       `yaml:"created_at"`
-	Metadata     sessionMetadata `yaml:"metadata"`
+	Name        string
+	SessionType string          `yaml:"session_type"`
+	Password    string          `yaml:"password"`
+	IP          string          `yaml:"ip"`
+	State       sessionState    `yaml:"state"`
+	Geometry    string          `yaml:"geometry"`
+	CreatedAt   time.Time       `yaml:"created_at"`
+	Metadata    sessionMetadata `yaml:"metadata"`
 }
 
 func loadAllSessions() ([]*Session, error) {
@@ -82,29 +84,29 @@ func loadSession(name string) (*Session, error) {
 	info, err := os.Stat(session.sessionDir())
 	if err != nil {
 		log.Debug("Error checking session dir", "sessionDir", session.sessionDir(), "err", err)
-		session.SessionState = Broken
+		session.State = Broken
 		return session, UnknownSession{Session: name}
 	}
 	if !info.IsDir() {
 		log.Debug("Session dir is not a directory", "sessionDir", session.sessionDir())
-		session.SessionState = Broken
+		session.State = Broken
 		return session, UnknownSession{Session: name}
 	}
 
 	data, err := os.ReadFile(session.metadataFile())
 	if err != nil {
 		log.Debug("Reading session metadata", "metadataFile", session.metadataFile(), "err", err)
-		session.SessionState = Broken
+		session.State = Broken
 		return session, nil
 	}
 	err = yaml.Unmarshal(data, &session)
 	if err != nil {
 		log.Debug("Loading session metadata", "metadataFile", session.metadataFile(), "err", err)
-		session.SessionState = Broken
+		session.State = Broken
 		return session, nil
 	}
 	if !session.isActive() {
-		session.SessionState = Exited
+		session.State = Exited
 	}
 	// Make certain that name isn't overridden by a value in the metadata file.
 	session.Name = name
@@ -134,7 +136,8 @@ func (s *Session) Start(ctx context.Context) error {
 		// command.
 		log.Debug("Failed to start cleaner script", "err", err)
 	}
-	s.SessionState = Active
+	s.State = Active
+	s.IP = s.PrimaryIP().String()
 	err := s.Save()
 	if err != nil {
 		return fmt.Errorf("saving session: %w", err)
@@ -194,6 +197,17 @@ func (s Session) PrimaryIP() netip.Addr {
 	return ip
 }
 
+func (s *Session) SessionState() sessionState {
+	if !s.IsLocal() {
+		return Remote
+	}
+	return s.State
+}
+
+func (s *Session) IsLocal() bool {
+	return s.IP == s.PrimaryIP().String()
+}
+
 func (s Session) Port() int {
 	display, err := strconv.Atoi(s.Display())
 	if err != nil {
@@ -204,11 +218,10 @@ func (s Session) Port() int {
 }
 
 func (s Session) PrimaryConnectionString() string {
-	if s.SessionState == Broken {
+	if s.State == Broken {
 		return ""
 	}
-	ip := s.PrimaryIP().String()
-	return fmt.Sprintf("%s:%d", ip, s.Port())
+	return fmt.Sprintf("%s:%d", s.IP, s.Port())
 }
 
 func (s Session) Display() string {

--- a/flight-desktop/session_clean.go
+++ b/flight-desktop/session_clean.go
@@ -60,7 +60,7 @@ You can specify which sessions are cleaned by providing the optional <id> parame
 			skipped := make([]*Session, 0)
 
 			for _, session := range sessions {
-				if session.SessionState == Active {
+				if !session.IsLocal() || session.State == Active {
 					skipped = append(skipped, session)
 				} else {
 					err := session.RemoveSessionDir()

--- a/flight-desktop/session_details.go
+++ b/flight-desktop/session_details.go
@@ -43,7 +43,7 @@ func sessionInfo(session *Session) {
 			dd.Render(session.Name),
 			dd.Render(session.SessionType),
 			dd.Render(session.Geometry),
-			dd.Render(string(session.SessionState)),
+			dd.Render(string(session.SessionState())),
 			dd.Render(session.CreatedAt.Format(time.RFC822)),
 		),
 	)
@@ -64,7 +64,7 @@ func connectionInfo(session *Session) {
 	} else {
 		username = u.Username
 	}
-	ip := session.PrimaryIP().String()
+	ip := session.IP
 	vnc := fmt.Sprintf("vnc://%s:%s@%s:%d", username, session.Password, ip, session.Port())
 	ipPort := session.PrimaryConnectionString()
 	ipDisplay := fmt.Sprintf("%s:%s", ip, session.Display())

--- a/flight-desktop/session_kill.go
+++ b/flight-desktop/session_kill.go
@@ -29,6 +29,12 @@ func killSessionCommand() *cli.Command {
 				}
 				return err
 			}
+			if !session.IsLocal() {
+				return cli.Exit(fmt.Sprintf("Desktop session '%s' is not local.\n", session.Name), 1)
+			}
+			if session.State != Active {
+				return cli.Exit(fmt.Sprintf("Desktop session '%s' is not active.\n", session.Name), 1)
+			}
 			p := pin.New(fmt.Sprintf("Killing desktop session %s", session.Name),
 				pin.WithSpinnerColor(pin.ColorCyan),
 				pin.WithTextColor(pin.ColorGreen),

--- a/flight-desktop/session_list.go
+++ b/flight-desktop/session_list.go
@@ -83,7 +83,7 @@ func sessionsTable(sessions []*Session) error {
 			s.SessionType,
 			connectionString,
 			s.Password,
-			string(s.SessionState),
+			string(s.SessionState()),
 		)
 	}
 	_, err := lipgloss.Println(t)

--- a/flight-desktop/session_show.go
+++ b/flight-desktop/session_show.go
@@ -28,7 +28,7 @@ func showSessionCommand() *cli.Command {
 				return err
 			}
 			sessionInfo(session)
-			if session.SessionState == Active {
+			if session.State != Exited && session.State != Broken {
 				connectionInfo(session)
 			}
 			managementInfo(session)

--- a/flight-desktop/session_start.go
+++ b/flight-desktop/session_start.go
@@ -77,10 +77,10 @@ func startSessionCommand() *cli.Command {
 			defer cancel()
 
 			session := Session{
-				Name:         name,
-				SessionState: New,
-				SessionType:  sessionType,
-				Geometry:     cmd.String("geometry"),
+				Name:        name,
+				State:       New,
+				SessionType: sessionType,
+				Geometry:    cmd.String("geometry"),
 			}
 			err = session.Start(ctx)
 			if err != nil {


### PR DESCRIPTION
It is expected that all nodes in the cluster will have access to the same home directory for the user and hence have access to the same directory where the flight desktop session data is stored.

This is useful as it allows for a user to run `flight desktop list` on a login node and get the connection details for a session started on, say, one of the compute nodes.  Sessions running on the current host are known as "local" sessions and those running on another host are known as "remote" sessions.

We only want to allow management of desktop sessions from the node on which they are running. It is not possible to kill a remote session and it is not possible to determine if a remote session should be cleaned. Attempting to kill or clean a remote session should be handled gracefully.