### PR TITLE
Blue-ify flight howto guides

### DIFF
--- a/flight-howto/opt/flight/usr/lib/flight-howto/themes/flight-dark.json
+++ b/flight-howto/opt/flight/usr/lib/flight-howto/themes/flight-dark.json
@@ -54,7 +54,7 @@
     "format": "\n--------\n"
   },
   "item": {
-    "block_prefix": "• "
+    "block_prefix": "\u001b[38;5;32;159;206m• \u001b[0m"
   },
   "enumeration": {
     "block_prefix": ". "

--- a/flight-howto/opt/flight/usr/lib/flight-howto/themes/flight-dark.json
+++ b/flight-howto/opt/flight/usr/lib/flight-howto/themes/flight-dark.json
@@ -64,11 +64,11 @@
     "unticked": "[ ] "
   },
   "link": {
-    "color": "30",
+    "color": "#83D0ED",
     "underline": true
   },
   "link_text": {
-    "color": "35",
+    "color": "#CCD0DA",
     "bold": true
   },
   "image": {
@@ -83,11 +83,11 @@
     "prefix": " ",
     "suffix": " ",
     "color": "#CCD0DA",
-    "background_color": "236"
+    "background_color": "#3D424A"
   },
   "code_block": {
     "margin": 4,
-    "theme": "solarized-dark"
+    "color": "#A2A7B4"
   },
   "table": {},
   "definition_list": {},

--- a/flight-howto/opt/flight/usr/lib/flight-howto/themes/flight-dark.json
+++ b/flight-howto/opt/flight/usr/lib/flight-howto/themes/flight-dark.json
@@ -15,32 +15,29 @@
   },
   "heading": {
     "block_suffix": "\n",
-    "color": "39",
+    "color": "#209FCE",
     "bold": true
   },
   "h1": {
     "prefix": " ",
     "suffix": " ",
-    "color": "228",
-    "background_color": "63",
-    "bold": true
+    "color": "#FFFDF5",
+    "background_color": "#2186CE"
   },
   "h2": {
-    "prefix": "## "
+    "prefix": "\n",
+    "color": "#41C2F2"
   },
   "h3": {
-    "prefix": "### "
   },
   "h4": {
-    "prefix": "#### "
+    "prefix": "# "
   },
   "h5": {
-    "prefix": "##### "
+    "prefix": "## "
   },
   "h6": {
-    "prefix": "###### ",
-    "color": "35",
-    "bold": false
+    "color": "#CCD0DA"
   },
   "text": {},
   "strikethrough": {
@@ -85,7 +82,7 @@
   "code": {
     "prefix": " ",
     "suffix": " ",
-    "color": "203",
+    "color": "#CCD0DA",
     "background_color": "236"
   },
   "code_block": {

--- a/flight-howto/opt/flight/usr/lib/flight-howto/themes/flight-light.json
+++ b/flight-howto/opt/flight/usr/lib/flight-howto/themes/flight-light.json
@@ -15,31 +15,29 @@
   },
   "heading": {
     "block_suffix": "\n",
-    "color": "27",
+    "color": "#5FBBDD",
     "bold": true
   },
   "h1": {
     "prefix": " ",
     "suffix": " ",
-    "color": "228",
-    "background_color": "63",
-    "bold": true
+    "color": "#FFFDF5",
+    "background_color": "#209FCE"
   },
   "h2": {
-    "prefix": "## "
+    "prefix": "\n",
+    "color": "#209FCE"
   },
   "h3": {
-    "prefix": "### "
   },
   "h4": {
-    "prefix": "#### "
+    "prefix": "# "
   },
   "h5": {
-    "prefix": "##### "
+    "prefix": "## "
   },
   "h6": {
-    "prefix": "###### ",
-    "bold": false
+    "color": "#2C3E50"
   },
   "text": {},
   "strikethrough": {
@@ -56,7 +54,7 @@
     "format": "\n--------\n"
   },
   "item": {
-    "block_prefix": "• "
+    "block_prefix": "\u001b[38;5;32;159;206m• \u001b[0m"
   },
   "enumeration": {
     "block_prefix": ". "
@@ -66,11 +64,11 @@
     "unticked": "[ ] "
   },
   "link": {
-    "color": "36",
+    "color": "#2C3E50",
     "underline": true
   },
   "link_text": {
-    "color": "29",
+    "color": "#2C3E50",
     "bold": true
   },
   "image": {
@@ -84,12 +82,12 @@
   "code": {
     "prefix": " ",
     "suffix": " ",
-    "color": "203",
-    "background_color": "254"
+    "color": "#2C3E50",
+    "background_color": "#E0E4EA"
   },
   "code_block": {
     "margin": 4,
-    "theme": "solarized-light"
+    "color": "#7F8594"
   },
   "table": {},
   "definition_list": {},


### PR DESCRIPTION
The markdown themes have been changed to use more alces-y colours.

The code block theme was removed as it seemed to colourise random words. Instead, I've just given code blocks a consistent grey text colour.

Resolves #64