### PR TITLE
Only show one welcome message when autostart is enabled.

### DIFF
--- a/flight-starter/opt/flight/usr/lib/hooks/login/welcome
+++ b/flight-starter/opt/flight/usr/lib/hooks/login/welcome
@@ -26,6 +26,21 @@
 # https://github.com/alces-flight/flight-user-suite
 #==============================================================================
 
+# Load in any settings set by 'flight config set'. Allowing per-user settings
+# to override global settings.
+if [ -e /etc/xdg/flight/settings.config ]; then
+  source /etc/xdg/flight/settings.config
+fi
+if [ -e "${XDG_CONFIG_HOME:-$HOME/.config}"/flight/settings.config ]; then
+  source "${XDG_CONFIG_HOME:-$HOME/.config}"/flight/settings.config
+fi
+
+if [ "${FLIGHT_AUTOSTART}" == "on" ] ; then
+  # The banner shown when flight is started is welcome enough; no need to
+  # also provide a separate welcome message.
+  exit 0
+fi
+
 IFS=: read -a xdg_config <<< "${XDG_CONFIG_HOME:-$HOME/.config}:${XDG_CONFIG_DIRS:-/etc/xdg}"
 for a in "${xdg_config[@]}"; do
   if [ -e "${a}"/flight.config ]; then

--- a/flight-starter/opt/flight/usr/lib/hooks/login/welcome
+++ b/flight-starter/opt/flight/usr/lib/hooks/login/welcome
@@ -26,6 +26,15 @@
 # https://github.com/alces-flight/flight-user-suite
 #==============================================================================
 
+IFS=: read -a xdg_config <<< "${XDG_CONFIG_HOME:-$HOME/.config}:${XDG_CONFIG_DIRS:-/etc/xdg}"
+for a in "${xdg_config[@]}"; do
+  if [ -e "${a}"/flight.config ]; then
+    source "${a}"/flight.config
+    break
+  fi
+done
+FLIGHT_ROOT="${FLIGHT_ROOT:-/opt/flight}"
+
 # Load in any settings set by 'flight config set'. Allowing per-user settings
 # to override global settings.
 if [ -e /etc/xdg/flight/settings.config ]; then
@@ -40,15 +49,6 @@ if [ "${FLIGHT_AUTOSTART}" == "on" ] ; then
   # also provide a separate welcome message.
   exit 0
 fi
-
-IFS=: read -a xdg_config <<< "${XDG_CONFIG_HOME:-$HOME/.config}:${XDG_CONFIG_DIRS:-/etc/xdg}"
-for a in "${xdg_config[@]}"; do
-  if [ -e "${a}"/flight.config ]; then
-    source "${a}"/flight.config
-    break
-  fi
-done
-FLIGHT_ROOT="${FLIGHT_ROOT:-/opt/flight}"
 
 if [ -f "${FLIGHT_ROOT}"/etc/flight-starter.config ]; then
   . "${FLIGHT_ROOT}"/etc/flight-starter.config


### PR DESCRIPTION
When autostart and the `welcome` hook are both enabled, we were printing two very similar welcome messages. Let's only print one.