### PR TITLE
Add `desktop logs` command.

### DIFF
--- a/flight-desktop/main.go
+++ b/flight-desktop/main.go
@@ -90,6 +90,7 @@ func main() {
 			startSessionCommand(),
 			listSessionsCommand(),
 			showSessionCommand(),
+			showSessionLogsCommand(),
 			killSessionCommand(),
 			cleanSessionCommand(),
 		},

--- a/flight-desktop/session_logs.go
+++ b/flight-desktop/session_logs.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/muesli/reflow/wordwrap"
+	"github.com/urfave/cli/v3"
+)
+
+func showSessionLogsCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "logs",
+		Usage:       "Show desktop session logs",
+		Description: wordwrap.String("Display logs for a desktop session.", maxTextWidth),
+		Category:    "Sessions",
+		Arguments: []cli.Argument{
+			&cli.StringArg{Name: "name", UsageText: "<name>"},
+		},
+		Before: assertArgPresent("name"),
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			name := cmd.StringArg("name")
+			session, err := loadSession(name)
+			if err != nil {
+				return err
+			}
+
+			logFile := filepath.Join(session.sessionDir(), "session.log")
+
+			log, err := os.Open(logFile)
+
+			if err != nil {
+				return fmt.Errorf("trying to read log file: %w", err)
+			}
+			defer log.Close()
+
+			scanner := bufio.NewScanner(log)
+
+			for scanner.Scan() {
+				line := scanner.Text()
+				fmt.Println(line)
+			}
+
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
<img width="703" height="577" alt="image" src="https://github.com/user-attachments/assets/9c49604b-a267-429b-9109-a53bdaa8ebf9" />

We don't concern ourselves with pagination as it's entirely suitable for piping into `less`. Essentially, it stops people needing to figure out the session directory themselves in order to view the logs.

Resolves #47.