### PR TITLE
Tools can specify their own synopsis

### DIFF
--- a/flight-core/main.go
+++ b/flight-core/main.go
@@ -302,16 +302,7 @@ Valid events are %s.`,
 	cmd.Commands = append(cmd.Commands, cmds...)
 }
 
-//go:embed tool_synopsis.txt
-var toolSynopsisString string
-
 func addToolProxyCommands(cmd *cli.Command) {
-	synopsisMap := make(map[string]string)
-	for line := range strings.Lines(toolSynopsisString) {
-		parts := strings.SplitN(line, ":", 2)
-		synopsisMap[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
-	}
-
 	tools, err := getTools(true)
 	if err != nil {
 		log.Warn("Unable to add tool proxy commands", "err", err)
@@ -324,8 +315,8 @@ func addToolProxyCommands(cmd *cli.Command) {
 			SkipFlagParsing: true,
 			Category:        "Available tools",
 		}
-		if synopsis, found := synopsisMap[tool.Name]; found {
-			proxy.Usage = synopsis
+		if tool.Synopsis != "" {
+			proxy.Usage = tool.Synopsis
 		}
 		cmd.Commands = append(cmd.Commands, &proxy)
 	}

--- a/flight-core/tool_synopsis.txt
+++ b/flight-core/tool_synopsis.txt
@@ -1,2 +1,0 @@
-desktop:Launch and manage virtual desktop sessions.
-howto:View user guides for your HPC environment.

--- a/flight-core/tools.go
+++ b/flight-core/tools.go
@@ -91,6 +91,9 @@ func toolsTable(tools []*Tool) error {
 
 func getTools(onlyEnabled bool) ([]*Tool, error) {
 	log.Debug("getting tools", "dir", toolDir, "onlyEnabled", onlyEnabled)
+
+	toolSynopsisDir := filepath.Join(flightRoot, "usr", "share", "doc", "tools")
+
 	entries, err := os.ReadDir(toolDir)
 	if err != nil {
 		return nil, fmt.Errorf("listing tools: %w", err)
@@ -103,7 +106,11 @@ func getTools(onlyEnabled bool) ([]*Tool, error) {
 				return nil, fmt.Errorf("reading tool info: %w", err)
 			}
 			enabled := info.Mode()&0111 != 0
-			tool := &Tool{Enabled: enabled, Name: toolName}
+
+			synopsisFile := filepath.Join(toolSynopsisDir, entry.Name())
+			synopsis, _ := os.ReadFile(synopsisFile)
+
+			tool := &Tool{Enabled: enabled, Name: toolName, Synopsis: string(synopsis)}
 
 			if !onlyEnabled || tool.Enabled {
 				tools = append(tools, tool)
@@ -156,8 +163,9 @@ func runTool(tool *Tool) func(ctx context.Context, cmd *cli.Command) error {
 }
 
 type Tool struct {
-	Enabled bool
-	Name    string
+	Enabled  bool
+	Name     string
+	Synopsis string
 }
 
 type DisabledTool struct {

--- a/flight-core/tools.go
+++ b/flight-core/tools.go
@@ -71,19 +71,19 @@ func toolsTable(tools []*Tool) error {
 			switch col {
 			case 0:
 				return style.Width(namecolWidth)
-			case 1:
+			case 2:
 				return style.Width(13)
 			}
 			return style
 		})
-	t.Headers("Name", "Enabled")
+	t.Headers("Name", "Description", "Enabled")
 	for _, tool := range tools {
 		namecolWidth = max(namecolWidth, len(tool.Name)+2)
 		enabledText := "\u274c Disabled"
 		if tool.Enabled {
 			enabledText = "\u2705 Enabled"
 		}
-		t.Row(tool.Name, enabledText)
+		t.Row(tool.Name, tool.Synopsis, enabledText)
 	}
 	_, err := lipgloss.Println(t)
 	return err

--- a/flight-desktop/opt/flight/usr/share/doc/tools/flight-desktop
+++ b/flight-desktop/opt/flight/usr/share/doc/tools/flight-desktop
@@ -1,0 +1,1 @@
+Launch and manage virtual desktop sessions.

--- a/flight-howto/opt/flight/usr/share/doc/tools/flight-howto
+++ b/flight-howto/opt/flight/usr/share/doc/tools/flight-howto
@@ -1,0 +1,1 @@
+View user guides for your HPC environment.


### PR DESCRIPTION
Previously, tool descriptions needed to be hard-coded in a `tool_synopsis.txt` file as part of `flight-core`.

Now, tools are able to specify this description themselves by adding a text file to `$FLIGHT_ROOT/usr/share/doc/tools` that matches the name of the tool executable. The files are read when composing the text for `flight --help`; I've also added a column to the table output by `flight tools list` as it seemed a useful place to present the information.

<img width="926" height="150" alt="image" src="https://github.com/user-attachments/assets/006c2172-3caa-4f99-af49-d8468cc0e791" />

Resolves #10.