### PR TITLE
Fix welcome hook and non interactive shells

### DIFF
--- a/flight-starter/etc/profile.d/zz-flight-starter.sh
+++ b/flight-starter/etc/profile.d/zz-flight-starter.sh
@@ -28,8 +28,8 @@ if [ -z "$BASH_VERSION" ]; then
   return
 fi
 
+FLIGHT_ROOT_ORIG="${FLIGHT_ROOT}"
 export FLIGHT_ROOT=${FLIGHT_ROOT:-/opt/flight}
-FLIGHT_ROOT_ORIG=${FLIGHT_ROOT}
 
 if [ "${-#*u}" != "$-" ]; then
   set +u
@@ -42,8 +42,10 @@ for a in "${xdg_config[@]}"; do
     break
   fi
 done
-# Honour the FLIGHT_ROOT setting initially set.
-FLIGHT_ROOT=${FLIGHT_ROOT_ORIG}
+if [ "${FLIGHT_ROOT_ORIG}" != "" ] ; then
+  # Honour the FLIGHT_ROOT setting initially set.
+  FLIGHT_ROOT=${FLIGHT_ROOT_ORIG}
+fi
 unset FLIGHT_ROOT_ORIG
 
 if [ "$(type -t flight-start)" != "function" ]; then

--- a/flight-starter/opt/flight/usr/lib/hooks/login/welcome
+++ b/flight-starter/opt/flight/usr/lib/hooks/login/welcome
@@ -26,6 +26,11 @@
 # https://github.com/alces-flight/flight-user-suite
 #==============================================================================
 
+if [ "${TERM}" == "" -o "${TERM}" == "dumb" ] ; then
+  # We don't have a TERM set. Calls to 'tput' will fail, so let's abort early.
+  exit 0
+fi
+
 IFS=: read -a xdg_config <<< "${XDG_CONFIG_HOME:-$HOME/.config}:${XDG_CONFIG_DIRS:-/etc/xdg}"
 for a in "${xdg_config[@]}"; do
   if [ -e "${a}"/flight.config ]; then


### PR DESCRIPTION
This fixes an issue where `tput` error messages would be sent to STDERR when sshing to a compute node and running a command directly. E.g.,

```bash
[rocky@login1 ~]$ ssh node01 /opt/flight/bin/flight desktop list
tput: No value for $TERM and no -T specified
tput: No value for $TERM and no -T specified
tput: No value for $TERM and no -T specified
tput: No value for $TERM and no -T specified
┌────────────────────┬────────┬────────────────────────────┬──────────┬────────┐
│        Name        │  Type  │     Connection string      │ Password │ State  │
├────────────────────┼────────┼────────────────────────────┼──────────┼────────┤
│ nearly-azure-xterm │ xterm  │ 10.10.0.101:5901           │ BH6W2LXT │ remote │
└────────────────────┴────────┴────────────────────────────┴──────────┴────────┘
```

An alternative fix might be to only run the hook for interactive shells. Whilst that sounds like a good solution, all of our hooks are currently executed rather than sourced. This means that the shell that is started to execute the welcome hook is never interactive.

There are some alternative possible fixes, but they all either have potentially wide ranging consequences or require considerably more work.

1. We could decide that (login?) hooks are never ran for non-interactive shells, but that would affect all (login?) hooks.
2. We could extend the hook mechanism to allow different hooks to specify whether they should be ran for non-interactive shells.
3. We could pass whether the calling shell is interactive to each hook as its first parameter.

Fixes #105 