### PR TITLE
Howto guides can override default name

### DIFF
--- a/flight-howto/guides.go
+++ b/flight-howto/guides.go
@@ -4,8 +4,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"charm.land/log/v2"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"gopkg.in/yaml.v3"
 )
 
@@ -16,7 +20,8 @@ type Howto struct {
 }
 
 type FrontMatter struct {
-	Admin bool `yaml:"admin"`
+	Admin bool   `yaml:"admin"`
+	Name  string `yaml:"name"`
 }
 
 func (h *Howto) FullPath() string {
@@ -68,6 +73,31 @@ func (h *Howto) IsAdminOnly() bool {
 		return false
 	}
 	return h.frontMatter.Admin
+}
+
+func (h *Howto) Name() string {
+	err := h.Read()
+	if err != nil {
+		return h.nameFromPath()
+	}
+	if h.frontMatter != nil && h.frontMatter.Name != "" {
+		return h.frontMatter.Name
+	}
+	return h.nameFromPath()
+}
+
+func (h *Howto) nameFromPath() string {
+	leadingDigits := regexp.MustCompile(`^\d+-\s*`)
+	otherDigits := regexp.MustCompile(`/\d+-\s*`)
+	name := strings.TrimSuffix(h.Path, ".md")
+
+	name = leadingDigits.ReplaceAllString(name, "")
+	name = otherDigits.ReplaceAllString(name, "/")
+	name = strings.ReplaceAll(name, "-", " ")
+	name = strings.ReplaceAll(name, "/", " > ")
+	return cases.
+		Title(language.English, cases.Compact).
+		String(name)
 }
 
 // Interface for sorting by howto path.

--- a/flight-howto/main.go
+++ b/flight-howto/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -20,8 +19,6 @@ import (
 	"github.com/concertim/flight-user-suite/flight/pkg"
 	"github.com/urfave/cli/v3"
 	"golang.org/x/term"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 var (
@@ -188,18 +185,6 @@ func loadHowtos(dirPath string, user *user.User) ([]*Howto, error) {
 	return howtos, nil
 }
 
-func prettyFilename(filename string) string {
-	leadingDigits := regexp.MustCompile(`^\d+-\s*`)
-	otherDigits := regexp.MustCompile(`/\d+-\s*`)
-	filename = leadingDigits.ReplaceAllString(filename, "")
-	filename = otherDigits.ReplaceAllString(filename, "/")
-	filename = strings.ReplaceAll(filename, "-", " ")
-	filename = strings.ReplaceAll(filename, "/", " > ")
-	return cases.
-		Title(language.English, cases.Compact).
-		String(filename)
-}
-
 func entriesTable(howtos []*Howto) error {
 	namecolWidth := 7
 	t := table.New().
@@ -224,12 +209,11 @@ func entriesTable(howtos []*Howto) error {
 		Width(termWidth)
 	t.Headers("Index", "Title")
 	for index, howto := range howtos {
-		name := strings.TrimSuffix(howto.Path, ".md")
 		id := strconv.Itoa(index + 1)
 		namecolWidth = max(namecolWidth, len(id)+2)
 		titleColumn := lipgloss.JoinVertical(
 			lipgloss.Left,
-			prettyFilename(name),
+			howto.Name(),
 		)
 		t.Row(id, titleColumn)
 	}


### PR DESCRIPTION
If the default name for a howto guide is not suitable, it can be overridden by specifying its name in its front matter. E.g.,

```
---
name: "Flight MFA"
---
```

Or

```
---
admin: true
name: "Admin Guides > Flight MFA"
---
```

As the second example implies, if the name is provided by front matter, it needs to provide the exact name that will be displayed in the `hwoto list` output, not just the final part.  This provides full flexibility, at the expense of a small amount of inconvenience.

Resolves #109