### PR TITLE
Add Bash shell completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ HPC environments.
 1. Download the latest release from [the releases page](https://github.com/concertim/flight-user-suite/releases).
 2. Copy the release tarball to the target system.
 3. Untar the release to `/`: it will install Flight User Suite to `/opt/flight`
-   along with configuration files `/etc/xdg/flight.config` and
-   `/etc/profile.d/zz-flight-starter.sh`.
+   along with a handful of configuration files outside of `/opt/flight`. You
+   can list the contents of the tarball to see those files.
 
 Once Flight User Suite has been installed, you can enable the hooks and tooling
 that you wish to make available.

--- a/flight-core/Makefile
+++ b/flight-core/Makefile
@@ -7,15 +7,21 @@ COMMIT := $(shell git rev-parse HEAD)
 DATE := $(shell date --rfc-3339=seconds)
 LD_FLAGS := -ldflags="-X 'main.version=$(VERSION)' -X 'main.commit=$(COMMIT)' -X 'main.date=$(DATE)'"
 
-.PHONY: all $(EXE) assets clean distclean
+.PHONY: all $(EXE) assets clean distclean shell_completions
 
-all: assets $(EXE)
+all: assets $(EXE) shell_completions
 
 $(EXE):
 	CGO_ENABLED=0 go build -v $(LD_FLAGS) -o $(EXE)
 
 assets:
 	rsync -rlptgo --exclude .gitkeep $(ASSET_DIRS) $(DIST)/
+
+shell_completions: $(DIST)/etc/bash_completions.d/flight
+
+$(DIST)/etc/bash_completions.d/flight: $(EXE)
+	mkdir -p $(dir $@)
+	$(EXE) completion bash > $@
 
 clean:
 	rm -f $(EXE)

--- a/flight-core/Makefile
+++ b/flight-core/Makefile
@@ -17,9 +17,9 @@ $(EXE):
 assets:
 	rsync -rlptgo --exclude .gitkeep $(ASSET_DIRS) $(DIST)/
 
-shell_completions: $(DIST)/etc/bash_completions.d/flight
+shell_completions: $(DIST)/usr/share/bash-completion/completions/flight
 
-$(DIST)/etc/bash_completions.d/flight: $(EXE)
+$(DIST)/usr/share/bash-completion/completions/flight: $(EXE)
 	mkdir -p $(dir $@)
 	$(EXE) completion bash > $@
 

--- a/flight-core/config_command.go
+++ b/flight-core/config_command.go
@@ -88,6 +88,18 @@ func configCommand() *cli.Command {
 					&cli.StringArg{Name: "value", UsageText: "<value>"},
 				},
 				Before: assertArgPresent("key", "value"),
+				ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+					switch cmd.NArg() {
+					case 0:
+						for _, key := range permittedKeys {
+							fmt.Println(key)
+						}
+					case 1:
+						for _, value := range permittedValues {
+							fmt.Println(value)
+						}
+					}
+				},
 				Action: configSet,
 			},
 			{
@@ -106,6 +118,14 @@ Currently supported keys are 'autostart'.`, maxTextWidth),
 					&cli.StringArg{Name: "key", UsageText: "<key>"},
 				},
 				Before: assertArgPresent("key"),
+				ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+					switch cmd.NArg() {
+					case 0:
+						for _, key := range permittedKeys {
+							fmt.Println(key)
+						}
+					}
+				},
 				Action: configGet,
 			},
 		},

--- a/flight-core/main.go
+++ b/flight-core/main.go
@@ -69,6 +69,20 @@ func main() {
 		UseShortOptionHandling: true,
 		HideHelpCommand:        true,
 		Description:            rootDescription(user, maxTextWidth),
+		EnableShellCompletion:  true,
+		ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+			cli.DefaultCompleteWithFlags(ctx, cmd)
+			switch cmd.NArg() {
+			case 0:
+				tools, err := getTools(true)
+				if err != nil {
+					return
+				}
+				for _, tool := range tools {
+					fmt.Println(tool.Name)
+				}
+			}
+		},
 		CommandNotFound: func(ctx context.Context, cmd *cli.Command, command string) {
 			fmt.Fprintf(
 				cmd.Root().Writer,
@@ -200,6 +214,20 @@ func addAdminCommands(cmd *cli.Command, maxTextWidth int) {
 						&cli.StringArg{Name: "tool", UsageText: "<tool>"},
 					},
 					Before: assertArgPresent("tool"),
+					ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+						switch cmd.NArg() {
+						case 0:
+							tools, err := getTools(false)
+							if err != nil {
+								return
+							}
+							for _, tool := range tools {
+								if !tool.Enabled {
+									fmt.Println(tool.Name)
+								}
+							}
+						}
+					},
 					Action: enableTool,
 				},
 				{
@@ -216,6 +244,18 @@ func addAdminCommands(cmd *cli.Command, maxTextWidth int) {
 						&cli.StringArg{Name: "tool", UsageText: "<tool>"},
 					},
 					Before: assertArgPresent("tool"),
+					ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+						switch cmd.NArg() {
+						case 0:
+							tools, err := getTools(true)
+							if err != nil {
+								return
+							}
+							for _, tool := range tools {
+								fmt.Println(tool.Name)
+							}
+						}
+					},
 					Action: disableTool,
 				},
 			},
@@ -277,6 +317,24 @@ Valid events are %s.`,
 						&cli.StringArg{Name: "hook", UsageText: "<hook>"},
 					},
 					Before: composeBeforeFuncs(assertArgPresent("event", "hook"), assertEventValid("event", 0)),
+					ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+						switch cmd.NArg() {
+						case 0:
+							for _, event := range validEvents {
+								fmt.Println(event)
+							}
+						case 1:
+							hooks, err := getEventHooks(cmd.Args().First(), false)
+							if err != nil {
+								return
+							}
+							for _, hook := range hooks {
+								if !hook.Enabled {
+									fmt.Println(hook.Name)
+								}
+							}
+						}
+					},
 					Action: enableHook,
 				},
 				{
@@ -294,6 +352,22 @@ Valid events are %s.`,
 						&cli.StringArg{Name: "hook", UsageText: "<hook>"},
 					},
 					Before: composeBeforeFuncs(assertArgPresent("event", "hook"), assertEventValid("event", 0)),
+					ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+						switch cmd.NArg() {
+						case 0:
+							for _, event := range validEvents {
+								fmt.Println(event)
+							}
+						case 1:
+							hooks, err := getEventHooks(cmd.Args().First(), true)
+							if err != nil {
+								return
+							}
+							for _, hook := range hooks {
+								fmt.Println(hook.Name)
+							}
+						}
+					},
 					Action: disableHook,
 				},
 			},
@@ -311,9 +385,14 @@ func addToolProxyCommands(cmd *cli.Command) {
 	for _, tool := range tools {
 		proxy := cli.Command{
 			Name:            tool.Name,
-			Action:          runTool(tool),
+			Action:          runToolAction(tool),
 			SkipFlagParsing: true,
 			Category:        "Available tools",
+			ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+				args := cmd.Args().Slice()
+				args = append(args, "--generate-shell-completion")
+				_ = runTool(ctx, tool, args)
+			},
 		}
 		if tool.Synopsis != "" {
 			proxy.Usage = tool.Synopsis

--- a/flight-core/opt/flight/usr/share/doc/flight-user-suite/99-admin-guides/flight-user-suite/01-install.md
+++ b/flight-core/opt/flight/usr/share/doc/flight-user-suite/99-admin-guides/flight-user-suite/01-install.md
@@ -6,8 +6,8 @@ admin: true
 1. Download the latest release from [the releases page](https://github.com/concertim/flight-user-suite/releases).
 2. Copy the release tarball to the target system.
 3. Untar the release to `/`: it will install Flight User Suite to `/opt/flight`
-   along with configuration files `/etc/xdg/flight.config` and
-   `/etc/profile.d/zz-flight-starter.sh`.
+   along with a handful of configuration files outside of `/opt/flight`. You
+   can list the contents of the tarball to see those files.
 
 Once Flight User Suite has been installed, you can enable the hooks and tooling
 that you wish to make available.

--- a/flight-core/tools.go
+++ b/flight-core/tools.go
@@ -149,20 +149,22 @@ func disableTool(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-func runTool(tool *Tool) func(ctx context.Context, cmd *cli.Command) error {
-	run := func(ctx context.Context, cmd *cli.Command) error {
-		tp := toolPath(tool.Name)
-		log.Debug("Execing", "tool", tool.Name, "path", tp, "args", cmd.Args().Slice())
-		exe := exec.CommandContext(ctx, tp, cmd.Args().Slice()...)
-		exe.Stdout = os.Stdout
-		exe.Stderr = os.Stderr
-		exe.Env = slices.Clone(os.Environ())
-		exe.Env = append(exe.Env, fmt.Sprintf("FLIGHT_PROGRAM_NAME=flight %s", tool.Name))
-		err := exe.Run()
-		return transformToolError(tool.Name, err)
+func runToolAction(tool *Tool) func(ctx context.Context, cmd *cli.Command) error {
+	return func(ctx context.Context, cmd *cli.Command) error {
+		return runTool(ctx, tool, cmd.Args().Slice())
 	}
+}
 
-	return run
+func runTool(ctx context.Context, tool *Tool, args []string) error {
+	tp := toolPath(tool.Name)
+	log.Debug("Execing", "tool", tool.Name, "path", tp, "args", args)
+	exe := exec.CommandContext(ctx, tp, args...)
+	exe.Stdout = os.Stdout
+	exe.Stderr = os.Stderr
+	exe.Env = slices.Clone(os.Environ())
+	exe.Env = append(exe.Env, fmt.Sprintf("FLIGHT_PROGRAM_NAME=flight %s", tool.Name))
+	err := exe.Run()
+	return transformToolError(tool.Name, err)
 }
 
 type Tool struct {

--- a/flight-desktop/main.go
+++ b/flight-desktop/main.go
@@ -63,6 +63,7 @@ func main() {
 		UseShortOptionHandling: true,
 		HideHelpCommand:        true,
 		Description:            wordwrap.String("Manage interactive GUI desktop sessions", maxTextWidth),
+		EnableShellCompletion:  true,
 		CommandNotFound: func(ctx context.Context, cmd *cli.Command, command string) {
 			fmt.Fprintf(
 				cmd.Root().Writer,

--- a/flight-desktop/session_clean.go
+++ b/flight-desktop/session_clean.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"charm.land/lipgloss/v2"
@@ -25,6 +26,7 @@ You can specify which sessions are cleaned by providing the optional <id> parame
 		Arguments: []cli.Argument{
 			&cli.StringArgs{Name: "id", UsageText: "[<id>...]", Min: 0, Max: -1},
 		},
+		ShellComplete: completeExitedSessionNames,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			ids := cmd.StringArgs("id")
 			var sessions []*Session
@@ -118,5 +120,20 @@ You can specify which sessions are cleaned by providing the optional <id> parame
 			lipgloss.Println(out)
 			return firstErr
 		},
+	}
+}
+
+func completeExitedSessionNames(ctx context.Context, cmd *cli.Command) {
+	switch cmd.NArg() {
+	case 0:
+		sessions, err := loadAllSessions()
+		if err != nil {
+			return
+		}
+		for _, session := range sessions {
+			if session.SessionState() == Exited {
+				fmt.Println(session.Name)
+			}
+		}
 	}
 }

--- a/flight-desktop/session_kill.go
+++ b/flight-desktop/session_kill.go
@@ -19,7 +19,8 @@ func killSessionCommand() *cli.Command {
 		Arguments: []cli.Argument{
 			&cli.StringArg{Name: "name", UsageText: "<name>"},
 		},
-		Before: assertArgPresent("name"),
+		Before:        assertArgPresent("name"),
+		ShellComplete: completeActiveSessionNames,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			name := cmd.StringArg("name")
 			session, err := loadSession(name)
@@ -54,6 +55,21 @@ func killSessionCommand() *cli.Command {
 			fmt.Printf("Desktop session '%s' has been terminated.\n", session.Name)
 			return nil
 		},
+	}
+}
+
+func completeActiveSessionNames(ctx context.Context, cmd *cli.Command) {
+	switch cmd.NArg() {
+	case 0:
+		sessions, err := loadAllSessions()
+		if err != nil {
+			return
+		}
+		for _, session := range sessions {
+			if session.SessionState() == Active {
+				fmt.Println(session.Name)
+			}
+		}
 	}
 }
 

--- a/flight-desktop/session_logs.go
+++ b/flight-desktop/session_logs.go
@@ -20,7 +20,8 @@ func showSessionLogsCommand() *cli.Command {
 		Arguments: []cli.Argument{
 			&cli.StringArg{Name: "name", UsageText: "<name>"},
 		},
-		Before: assertArgPresent("name"),
+		Before:        assertArgPresent("name"),
+		ShellComplete: completeSessionNames,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			name := cmd.StringArg("name")
 			session, err := loadSession(name)

--- a/flight-desktop/session_show.go
+++ b/flight-desktop/session_show.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"charm.land/log/v2"
 	"github.com/muesli/reflow/wordwrap"
@@ -17,7 +18,8 @@ func showSessionCommand() *cli.Command {
 		Arguments: []cli.Argument{
 			&cli.StringArg{Name: "name", UsageText: "<name>"},
 		},
-		Before: assertArgPresent("name"),
+		Before:        assertArgPresent("name"),
+		ShellComplete: completeSessionNames,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			name := cmd.StringArg("name")
 			session, err := loadSession(name)
@@ -34,5 +36,18 @@ func showSessionCommand() *cli.Command {
 			managementInfo(session)
 			return nil
 		},
+	}
+}
+
+func completeSessionNames(ctx context.Context, cmd *cli.Command) {
+	switch cmd.NArg() {
+	case 0:
+		sessions, err := loadAllSessions()
+		if err != nil {
+			return
+		}
+		for _, session := range sessions {
+			fmt.Println(session.Name)
+		}
 	}
 }

--- a/flight-desktop/session_start.go
+++ b/flight-desktop/session_start.go
@@ -58,6 +58,19 @@ func startSessionCommand() *cli.Command {
 			&cli.StringArg{Name: "type", UsageText: "<type>"},
 		},
 		Before: composeBeforeFuncs(assertArgPresent("type"), assertTypeValid("type", 0)),
+		ShellComplete: func(ctx context.Context, cmd *cli.Command) {
+			cli.DefaultCompleteWithFlags(ctx, cmd)
+			switch cmd.NArg() {
+			case 0:
+				types, err := loadAllTypes()
+				if err != nil {
+					return
+				}
+				for _, t := range types {
+					fmt.Println(t.ID)
+				}
+			}
+		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			sessionType := cmd.StringArg("type")
 			name := cmd.String("name")

--- a/flight-howto/main.go
+++ b/flight-howto/main.go
@@ -48,10 +48,11 @@ func init() {
 
 func main() {
 	cmd := &cli.Command{
-		Name:        "flight howto",
-		Usage:       "View user guides for your HPC environment",
-		Description: lipgloss.Wrap("View user guides for your HPC environment", maxTextWidth, " "),
-		Copyright:   "(c) 2026 Stephen F Norledge & Alces Software Ltd & Concertim Ltd.",
+		Name:                  "flight howto",
+		Usage:                 "View user guides for your HPC environment",
+		Description:           lipgloss.Wrap("View user guides for your HPC environment", maxTextWidth, " "),
+		Copyright:             "(c) 2026 Stephen F Norledge & Alces Software Ltd & Concertim Ltd.",
+		EnableShellCompletion: true,
 		Commands: []*cli.Command{
 			{
 				Name:    "list",

--- a/flight-mfa/opt/flight/usr/lib/flight-core/flight-mfa
+++ b/flight-mfa/opt/flight/usr/lib/flight-core/flight-mfa
@@ -27,6 +27,14 @@
 #==============================================================================
 
 _flightmfa_main() {
+  if [[ $* == *--generate-shell-completion* ]] ; then
+    if [ $# -lt 2 ] ; then
+      echo generate
+      echo show
+    fi
+    return 0
+  fi
+
   case $1 in
     generate)
       shift


### PR DESCRIPTION
This PR adds support for tab completion for the Bash shell.

The particulars of how commands complete can be found on #111.

The implementation is relatively straightforward, but a couple of things are worth calling out.

During the build process, bash completion configuration is generated and installed at `/etc/bash_completion.d/flight`.  This is only generated for the `flight` command, e.g., `flight-core`.

If a user types `flight <tool> <tab>`, a request for completions is sent to the `flight` command by the shell.  `flight` proxies that request to the tool by running `$FLIGHT_ROOT/usr/lib/flight-core/flight-<tool> --generate-shell-completion`.  This results in shell completion working for all of our tools as long as they are accessed via `flight <tool>`.

---

A completion script can be generated for ZSH by running:

```bash
/opt/flight/bin/flight completion zsh
```

It is left as an exercise for ZSH users to figure out where that output should be placed.

Similarly, a completion script can be generated for Fish by running:

```bash
/opt/flight/bin/flight completion fish
```


Resolves #111 