### PR TITLE
Add synopsis for MFA and config commands

### DIFF
--- a/flight-core/config_command.go
+++ b/flight-core/config_command.go
@@ -56,6 +56,7 @@ func configCommand() *cli.Command {
 
 	return &cli.Command{
 		Name:        "config",
+		Usage:       "Manage Flight User Suite settings",
 		Description: wordwrap.String(fmt.Sprintf("Manage Flight User Suite settings. Available settings are shown below:\n\n%s", settingsList), maxTextWidth),
 		Category:    "Configuration",
 		Commands: []*cli.Command{

--- a/flight-core/tools.go
+++ b/flight-core/tools.go
@@ -111,7 +111,7 @@ func getTools(onlyEnabled bool) ([]*Tool, error) {
 			synopsisFile := filepath.Join(toolSynopsisDir, entry.Name())
 			synopsis, _ := os.ReadFile(synopsisFile)
 
-			tool := &Tool{Enabled: enabled, Name: toolName, Synopsis: string(synopsis)}
+			tool := &Tool{Enabled: enabled, Name: toolName, Synopsis: strings.TrimSpace(string(synopsis))}
 
 			if !onlyEnabled || tool.Enabled {
 				tools = append(tools, tool)

--- a/flight-mfa/opt/flight/usr/share/doc/tools/flight-mfa
+++ b/flight-mfa/opt/flight/usr/share/doc/tools/flight-mfa
@@ -1,0 +1,1 @@
+Manage multi-factor authentication configuration


### PR DESCRIPTION
Also, trim leading and trailing spaces for tool synopsis.