### PR TITLE
Web suite lists desktop sessions

### DIFF
--- a/flight-core/main.go
+++ b/flight-core/main.go
@@ -14,6 +14,7 @@ import (
 	"charm.land/log/v2"
 	"github.com/concertim/flight-user-suite/flight/cliui"
 	"github.com/concertim/flight-user-suite/flight/configenv"
+	"github.com/concertim/flight-user-suite/flight/toolset"
 	"github.com/muesli/reflow/wordwrap"
 	"github.com/urfave/cli/v3"
 	"golang.org/x/term"
@@ -76,7 +77,7 @@ func main() {
 			cli.DefaultCompleteWithFlags(ctx, cmd)
 			switch cmd.NArg() {
 			case 0:
-				tools, err := getTools(true)
+				tools, err := toolset.GetTools(env.FlightRoot, true)
 				if err != nil {
 					return
 				}
@@ -219,7 +220,7 @@ func addAdminCommands(cmd *cli.Command, maxTextWidth int) {
 					ShellComplete: func(ctx context.Context, cmd *cli.Command) {
 						switch cmd.NArg() {
 						case 0:
-							tools, err := getTools(false)
+							tools, err := toolset.GetTools(env.FlightRoot, false)
 							if err != nil {
 								return
 							}
@@ -249,7 +250,7 @@ func addAdminCommands(cmd *cli.Command, maxTextWidth int) {
 					ShellComplete: func(ctx context.Context, cmd *cli.Command) {
 						switch cmd.NArg() {
 						case 0:
-							tools, err := getTools(true)
+							tools, err := toolset.GetTools(env.FlightRoot, false)
 							if err != nil {
 								return
 							}
@@ -396,7 +397,7 @@ The Flight Web Suite provides in-browser access to the Flight User Suite tools.`
 }
 
 func addToolProxyCommands(cmd *cli.Command) {
-	tools, err := getTools(true)
+	tools, err := toolset.GetTools(env.FlightRoot, false)
 	if err != nil {
 		log.Warn("Unable to add tool proxy commands", "err", err)
 		return

--- a/flight-core/shell.go
+++ b/flight-core/shell.go
@@ -14,6 +14,7 @@ import (
 	"charm.land/log/v2"
 	"github.com/adrg/xdg"
 	"github.com/concertim/flight-user-suite/flight/cliui"
+	"github.com/concertim/flight-user-suite/flight/toolset"
 	"github.com/ergochat/readline"
 	"github.com/urfave/cli/v3"
 )
@@ -33,7 +34,7 @@ func toolCompletions(line string) []string {
 		cmdComplete = true
 	}
 
-	tools, err := getTools(true)
+	tools, err := toolset.GetTools(env.FlightRoot, false)
 	if err != nil {
 		log.Warn("Error", "err", err)
 		return nil
@@ -58,7 +59,7 @@ func toolCompletions(line string) []string {
 		// "help"), we offer no completions.
 		return nil
 	}
-	tool := &Tool{Name: cmd}
+	tool := &toolset.Tool{Name: cmd}
 
 	// Request completion from tool. Omit the final word if incomplete.
 	var toolArgs []string

--- a/flight-core/tools.go
+++ b/flight-core/tools.go
@@ -9,12 +9,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
-	"strings"
 
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/table"
 	"charm.land/log/v2"
 	"github.com/concertim/flight-user-suite/flight/cliui"
+	"github.com/concertim/flight-user-suite/flight/toolset"
 	"github.com/urfave/cli/v3"
 )
 
@@ -38,7 +38,7 @@ func transformToolError(tool string, err error) error {
 
 func listTools(ctx context.Context, cmd *cli.Command) error {
 	onlyEnabled := cmd.Bool("enabled")
-	tools, err := getTools(onlyEnabled)
+	tools, err := toolset.GetTools(env.FlightRoot, onlyEnabled)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func listTools(ctx context.Context, cmd *cli.Command) error {
 	return toolsTable(tools)
 }
 
-func toolsTable(tools []*Tool) error {
+func toolsTable(tools []*toolset.Tool) error {
 	namecolWidth := 8
 
 	t := table.New().
@@ -90,37 +90,6 @@ func toolsTable(tools []*Tool) error {
 	return err
 }
 
-func getTools(onlyEnabled bool) ([]*Tool, error) {
-	log.Debug("getting tools", "dir", toolDir, "onlyEnabled", onlyEnabled)
-
-	toolSynopsisDir := filepath.Join(env.FlightRoot, "usr", "share", "doc", "tools")
-
-	entries, err := os.ReadDir(toolDir)
-	if err != nil {
-		return nil, fmt.Errorf("listing tools: %w", err)
-	}
-	tools := make([]*Tool, 0)
-	for _, entry := range entries {
-		if toolName, hasPrefix := strings.CutPrefix(entry.Name(), "flight-"); hasPrefix {
-			info, err := entry.Info()
-			if err != nil {
-				return nil, fmt.Errorf("reading tool info: %w", err)
-			}
-			enabled := info.Mode()&0111 != 0
-
-			synopsisFile := filepath.Join(toolSynopsisDir, entry.Name())
-			synopsis, _ := os.ReadFile(synopsisFile)
-
-			tool := &Tool{Enabled: enabled, Name: toolName, Synopsis: strings.TrimSpace(string(synopsis))}
-
-			if !onlyEnabled || tool.Enabled {
-				tools = append(tools, tool)
-			}
-		}
-	}
-	return tools, nil
-}
-
 func enableTool(ctx context.Context, cmd *cli.Command) error {
 	tool := cmd.StringArg("tool")
 	tp := toolPath(tool)
@@ -149,13 +118,13 @@ func disableTool(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-func runToolAction(tool *Tool) func(ctx context.Context, cmd *cli.Command) error {
+func runToolAction(tool *toolset.Tool) func(ctx context.Context, cmd *cli.Command) error {
 	return func(ctx context.Context, cmd *cli.Command) error {
 		return runTool(ctx, tool, cmd.Args().Slice())
 	}
 }
 
-func buildToolExecCmd(ctx context.Context, tool *Tool, args []string) *exec.Cmd {
+func buildToolExecCmd(ctx context.Context, tool *toolset.Tool, args []string) *exec.Cmd {
 	tp := toolPath(tool.Name)
 	log.Debug("Execing", "tool", tool.Name, "path", tp, "args", args)
 	exe := exec.CommandContext(ctx, tp, args...)
@@ -164,7 +133,7 @@ func buildToolExecCmd(ctx context.Context, tool *Tool, args []string) *exec.Cmd 
 	return exe
 }
 
-func runTool(ctx context.Context, tool *Tool, args []string) error {
+func runTool(ctx context.Context, tool *toolset.Tool, args []string) error {
 	exe := buildToolExecCmd(ctx, tool, args)
 	exe.Stdout = os.Stdout
 	exe.Stderr = os.Stderr
@@ -173,24 +142,18 @@ func runTool(ctx context.Context, tool *Tool, args []string) error {
 }
 
 // Run the specified tool and return its Stdout.
-func runToolWithOutput(ctx context.Context, tool *Tool, args []string) ([]byte, error) {
+func runToolWithOutput(ctx context.Context, tool *toolset.Tool, args []string) ([]byte, error) {
 	exe := buildToolExecCmd(ctx, tool, args)
 	output, err := exe.Output()
 	return output, transformToolError(tool.Name, err)
-}
-
-type Tool struct {
-	Enabled  bool
-	Name     string
-	Synopsis string
 }
 
 type DisabledTool struct {
 	Tool string
 }
 
-func (ut DisabledTool) Error() string {
-	return fmt.Sprintf("The %s tool is not enabled", ut.Tool)
+func (dt DisabledTool) Error() string {
+	return fmt.Sprintf("The %s tool is not enabled", dt.Tool)
 }
 
 type UnknownTool struct {

--- a/flight-core/toolset/toolset.go
+++ b/flight-core/toolset/toolset.go
@@ -1,0 +1,62 @@
+package toolset
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Tool struct {
+	Enabled  bool
+	Name     string
+	Synopsis string
+}
+
+func GetTools(flightRoot string, onlyEnabled bool) ([]*Tool, error) {
+	toolDir := filepath.Join(flightRoot, "usr", "lib", "flight-core")
+	toolSynopsisDir := filepath.Join(flightRoot, "usr", "share", "doc", "tools")
+
+	entries, err := os.ReadDir(toolDir)
+	if err != nil {
+		return nil, fmt.Errorf("listing tools: %w", err)
+	}
+
+	tools := make([]*Tool, 0)
+	for _, entry := range entries {
+		if toolName, hasPrefix := strings.CutPrefix(entry.Name(), "flight-"); hasPrefix {
+			info, err := entry.Info()
+			if err != nil {
+				return nil, fmt.Errorf("reading tool info: %w", err)
+			}
+			enabled := info.Mode()&0o111 != 0
+
+			synopsisFile := filepath.Join(toolSynopsisDir, entry.Name())
+			synopsis, _ := os.ReadFile(synopsisFile)
+
+			tool := &Tool{
+				Enabled:  enabled,
+				Name:     toolName,
+				Synopsis: strings.TrimSpace(string(synopsis)),
+			}
+			if !onlyEnabled || tool.Enabled {
+				tools = append(tools, tool)
+			}
+		}
+	}
+
+	return tools, nil
+}
+
+func GetTool(flightRoot, toolName string) (*Tool, error) {
+	tools, err := GetTools(flightRoot, false)
+	if err != nil {
+		return nil, err
+	}
+	for _, tool := range tools {
+		if tool.Name == toolName {
+			return tool, nil
+		}
+	}
+	return nil, fmt.Errorf("unknown tool: %s", toolName)
+}

--- a/flight-desktop/session_list.go
+++ b/flight-desktop/session_list.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"time"
 
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/table"
@@ -17,22 +20,58 @@ func listSessionsCommand() *cli.Command {
 		Usage:       "List interactive desktop sessions",
 		Description: wordwrap.String("Display all known desktop sessions and their states.", 80),
 		Category:    "Sessions",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "format",
+				Value: "pretty",
+				Usage: "output sessions in the specified `FORMAT` (pretty, json).",
+				Validator: func(format string) error {
+					if format != "pretty" && format != "json" {
+						return fmt.Errorf("%s is not a known format (pretty, json)", format)
+					}
+					return nil
+				},
+			},
+		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			sessions, err := loadAllSessions()
 			if err != nil {
 				return err
 			}
+			if cmd.String("format") == "json" {
+				return writeSessionsJSON(sessions)
+			}
 			if len(sessions) == 0 {
 				fmt.Println("No desktop sessions found.")
 				return nil
 			}
-			err = sessionsTable(sessions)
-			if err != nil {
-				return err
-			}
-			return nil
+			return sessionsTable(sessions)
 		},
 	}
+}
+
+type listedSession struct {
+	Name        string       `json:"name"`
+	DesktopType string       `json:"desktop_type"`
+	State       sessionState `json:"state"`
+	Host        string       `json:"host"`
+	CreatedAt   string       `json:"created_at"`
+}
+
+func writeSessionsJSON(sessions []*Session) error {
+	output := make([]listedSession, 0, len(sessions))
+	for _, session := range sessions {
+		output = append(output, listedSession{
+			Name:        session.Name,
+			DesktopType: session.SessionType,
+			State:       session.SessionState(),
+			Host:        session.Metadata.Host,
+			CreatedAt:   session.CreatedAt.Format(time.RFC3339),
+		})
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(output)
 }
 
 func sessionsTable(sessions []*Session) error {

--- a/flight-desktop/session_list_test.go
+++ b/flight-desktop/session_list_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestWriteSessionsJSON(t *testing.T) {
+	sessions := []*Session{
+		{
+			Name:        "alpha",
+			SessionType: "gnome",
+			State:       Active,
+			CreatedAt:   time.Date(2026, time.April, 21, 11, 30, 0, 0, time.UTC),
+			Metadata: sessionMetadata{
+				Host: "desktop-a",
+			},
+		},
+	}
+
+	originalStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = writer
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+	})
+
+	if err := writeSessionsJSON(sessions); err != nil {
+		t.Fatalf("writeSessionsJSON returned error: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("failed to close writer: %v", err)
+	}
+
+	var got []listedSession
+	if err := json.NewDecoder(reader).Decode(&got); err != nil {
+		t.Fatalf("failed to decode JSON output: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(got))
+	}
+
+	session := got[0]
+	if session.Name != "alpha" {
+		t.Errorf("expected name alpha, got %q", session.Name)
+	}
+	if session.DesktopType != "gnome" {
+		t.Errorf("expected desktop type gnome, got %q", session.DesktopType)
+	}
+	if session.State != Remote {
+		t.Errorf("expected state %q, got %q", Remote, session.State)
+	}
+	if session.Host != "desktop-a" {
+		t.Errorf("expected host desktop-a, got %q", session.Host)
+	}
+	if session.CreatedAt != "2026-04-21T11:30:00Z" {
+		t.Errorf("expected created at 2026-04-21T11:30:00Z, got %q", session.CreatedAt)
+	}
+}

--- a/flight-desktop/testdata/golden/list-help.golden
+++ b/flight-desktop/testdata/golden/list-help.golden
@@ -11,7 +11,8 @@ DESCRIPTION:
    Display all known desktop sessions and their states.
 
 OPTIONS:
-   --help, -h  show help
+   --format FORMAT  output sessions in the specified FORMAT (pretty, json). (default: "pretty")
+   --help, -h       show help
 
 GLOBAL OPTIONS:
    --log-level LEVEL  set the log LEVEL (debug, info, warn, error, fatal). Default: warn

--- a/flight-web-suite/desktop_sessions.go
+++ b/flight-web-suite/desktop_sessions.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/concertim/flight-user-suite/flight/toolset"
+	"github.com/labstack/echo/v5"
+)
+
+type desktopSession struct {
+	Name        string    `json:"name"`
+	DesktopType string    `json:"desktop_type"`
+	State       string    `json:"state"`
+	Host        string    `json:"host"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+type desktopSessionCard struct {
+	Name          string
+	DesktopType   string
+	State         string
+	Host          string
+	StartTimeText string
+}
+
+func indexDesktopSessionsHandler(c *echo.Context) error {
+	if !IsLoggedIn(c) {
+		return c.Redirect(http.StatusSeeOther, "/sessions")
+	}
+
+	tool, err := toolset.GetTool(env.FlightRoot, "desktop")
+	if err != nil || !tool.Enabled {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "Flight Desktop is not enabled")
+	}
+
+	sessions, err := listDesktopSessions(c.Request().Context(), CurrentUserName(c))
+	if err != nil {
+		return err
+	}
+
+	slices.SortFunc(sessions, func(a, b desktopSession) int {
+		if byName := strings.Compare(a.Name, b.Name); byName != 0 {
+			return byName
+		}
+		return a.CreatedAt.Compare(b.CreatedAt)
+	})
+
+	data := map[string]any{
+		"Summary":         desktopSessionsSummary(sessions),
+		"DesktopSessions": buildDesktopSessionCards(sessions),
+	}
+	return c.Render(http.StatusOK, "desktop/index", AddCommonData(c, data))
+}
+
+func buildDesktopSessionCards(sessions []desktopSession) []desktopSessionCard {
+	cards := make([]desktopSessionCard, 0, len(sessions))
+	for _, session := range sessions {
+		cards = append(cards, desktopSessionCard{
+			Name:          session.Name,
+			DesktopType:   session.DesktopType,
+			State:         session.State,
+			Host:          session.Host,
+			StartTimeText: session.CreatedAt.Format("Mon 2 Jan 2006 15:04"),
+		})
+	}
+	return cards
+}
+
+func desktopSessionsSummary(sessions []desktopSession) string {
+	count := len(sessions)
+	runningCount := 0
+	if count == 0 {
+		return "You don't have any sessions currently running."
+	}
+
+	for _, s := range sessions {
+		if s.State == "active" || s.State == "remote" {
+			runningCount += 1
+		}
+	}
+	if runningCount == count {
+		if count == 1 {
+			return "You have 1 desktop session currently running."
+		}
+		return fmt.Sprintf("You have %d desktop sessions currently running.", count)
+	}
+
+	nonRunningCount := count - runningCount
+	nonRunningString := fmt.Sprintf("and %d stale sessions.", nonRunningCount)
+	if nonRunningCount == 1 {
+		nonRunningString = "and 1 stale session."
+	}
+
+	if runningCount == 0 {
+		return fmt.Sprintf("You don't have any desktop sessions currently running %s", nonRunningString)
+	}
+	if runningCount == 1 {
+		return fmt.Sprintf("You have 1 desktop session currently running %s", nonRunningString)
+	}
+	return fmt.Sprintf("You have %d desktop sessions currently running %s", runningCount, nonRunningString)
+}
+
+func listDesktopSessions(ctx context.Context, username string) ([]desktopSession, error) {
+	userInfo, err := user.Lookup(username)
+	if err != nil {
+		return nil, fmt.Errorf("looking up user %q: %w", username, err)
+	}
+
+	cmd, err := desktopListCommand(ctx, userInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if stderr.Len() != 0 {
+			return nil, fmt.Errorf("listing desktop sessions: %s", stderr.String())
+		}
+		return nil, fmt.Errorf("listing desktop sessions: %w", err)
+	}
+
+	var sessions []desktopSession
+	if err := json.Unmarshal(stdout.Bytes(), &sessions); err != nil {
+		return nil, fmt.Errorf("decoding desktop sessions: %w", err)
+	}
+	return sessions, nil
+}
+
+func desktopListCommand(ctx context.Context, userInfo *user.User) (*exec.Cmd, error) {
+	uid, err := strconv.Atoi(userInfo.Uid)
+	if err != nil {
+		return nil, fmt.Errorf("parsing uid for user %q: %w", userInfo.Username, err)
+	}
+	gid, err := strconv.Atoi(userInfo.Gid)
+	if err != nil {
+		return nil, fmt.Errorf("parsing gid for user %q: %w", userInfo.Username, err)
+	}
+
+	groupIDs, err := userInfo.GroupIds()
+	if err != nil {
+		return nil, fmt.Errorf("looking up groups for user %q: %w", userInfo.Username, err)
+	}
+	groups := make([]uint32, 0, len(groupIDs))
+	for _, groupID := range groupIDs {
+		parsed, err := strconv.Atoi(groupID)
+		if err != nil {
+			return nil, fmt.Errorf("parsing group id %q for user %q: %w", groupID, userInfo.Username, err)
+		}
+		groups = append(groups, uint32(parsed))
+	}
+
+	cmd := exec.CommandContext(ctx, desktopToolPath(), "list", "--format", "json")
+	cmd.Dir = userInfo.HomeDir
+	cmd.Env = desktopCommandEnv(userInfo)
+	if os.Geteuid() == 0 {
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Credential: &syscall.Credential{
+				Uid:    uint32(uid),
+				Gid:    uint32(gid),
+				Groups: groups,
+			},
+		}
+	} else if os.Geteuid() != uid {
+		return nil, fmt.Errorf("cannot run desktop listing as %q without root privileges", userInfo.Username)
+	}
+	return cmd, nil
+}
+
+func desktopToolPath() string {
+	return filepath.Join(env.FlightRoot, "usr", "lib", "flight-core", "flight-desktop")
+}
+
+func desktopCommandEnv(userInfo *user.User) []string {
+	env := slices.Clone(os.Environ())
+	env = slices.DeleteFunc(env, func(envar string) bool {
+		parts := strings.SplitN(envar, "=", 2)
+		name := parts[0]
+		return strings.HasPrefix(name, "XDG_")
+	})
+	env = upsertEnv(env, "HOME", userInfo.HomeDir)
+	env = upsertEnv(env, "LOGNAME", userInfo.Username)
+	env = upsertEnv(env, "USER", userInfo.Username)
+	return env
+}
+
+func upsertEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	for i, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			env[i] = prefix + value
+			return env
+		}
+	}
+	return append(env, prefix+value)
+}

--- a/flight-web-suite/desktop_sessions_functional_test.go
+++ b/flight-web-suite/desktop_sessions_functional_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/concertim/flight-user-suite/flight-web-suite/internal/testutil"
+)
+
+func TestDesktopSessionsRedirectsForAnonymous(t *testing.T) {
+	resp, _ := testutil.RenderPage(t, newApp(), http.MethodGet, "/desktop", nil, http.StatusSeeOther)
+
+	if resp.Header.Get("location") != "/sessions" {
+		t.Errorf("expected desktop sessions page to redirect to '/sessions' for anonymous users")
+	}
+}
+
+func TestDesktopSessionsPageDisplaysSessions(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+cat <<'JSON'
+[
+  {
+    "name": "alpha",
+    "desktop_type": "Gnome",
+    "state": "active",
+    "host": "host-a",
+    "created_at": "2026-04-20T10:00:00Z"
+  },
+  {
+    "name": "beta",
+    "desktop_type": "Xfce",
+    "state": "broken",
+    "host": "host-b",
+    "created_at": "2026-04-21T11:30:00Z"
+  }
+]
+JSON
+`))
+
+	_, body := testutil.RenderPage(t, newApp(), http.MethodGet, "/desktop", nil, http.StatusOK, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	assertAuthenticated(t, body, currentUser.Username)
+	testutil.AssertSelection(t, body, `[data-testid="desktop-sessions-summary"]`,
+		testutil.HasText("You have 1 desktop session currently running and 1 stale session."),
+	)
+	testutil.AssertSelection(t, body, `[data-testid="desktop-session-card--alpha"] h2`,
+		testutil.HasText("alpha"),
+	)
+	testutil.AssertSelection(t, body, `[data-testid="desktop-session-desktop-type--alpha"]`,
+		testutil.HasText("Gnome"),
+	)
+	testutil.AssertSelection(t, body, `[data-testid="desktop-session-state--alpha"]`,
+		testutil.HasText("active"),
+	)
+	testutil.AssertSelection(t, body, `[data-testid="desktop-session-host--alpha"]`,
+		testutil.HasText("host-a"),
+	)
+	testutil.AssertSelection(t, body, `[data-testid="desktop-session-start-time--alpha"]`,
+		testutil.HasText("Mon 20 Apr 2026 10:00"),
+	)
+	testutil.AssertSelection(t, body, `[data-testid="desktop-session-card--beta"] h2`,
+		testutil.HasText("beta"),
+	)
+}
+
+func TestDesktopSessionsPageReturnsServiceUnavailableWhenToolDisabled(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o644, `#!/bin/sh
+echo '[]'
+`))
+
+	_, body := testutil.RenderPage(t, newApp(), http.MethodGet, "/desktop", nil, http.StatusServiceUnavailable, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	if want := "Flight Desktop is not enabled"; !strings.Contains(body, want) {
+		t.Fatalf("expected body to contain %q, got %q", want, body)
+	}
+}
+
+func currentUserForTest(t *testing.T) *user.User {
+	t.Helper()
+
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatalf("failed to determine current user: %v", err)
+	}
+	return currentUser
+}
+
+func setFlightRootForDesktopTest(t *testing.T, root string) {
+	t.Helper()
+
+	original := env.FlightRoot
+	env.FlightRoot = root
+	t.Cleanup(func() {
+		env.FlightRoot = original
+	})
+}
+
+func desktopToolFixture(t *testing.T, mode os.FileMode, script string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	toolPath := filepath.Join(root, "usr", "lib", "flight-core", "flight-desktop")
+	if err := os.MkdirAll(filepath.Dir(toolPath), 0o755); err != nil {
+		t.Fatalf("failed to create tool dir: %v", err)
+	}
+	if err := os.WriteFile(toolPath, []byte(script), mode); err != nil {
+		t.Fatalf("failed to write desktop tool fixture: %v", err)
+	}
+	synopsisDir := filepath.Join(root, "usr", "share", "doc", "tools")
+	if err := os.MkdirAll(synopsisDir, 0o755); err != nil {
+		t.Fatalf("failed to create synopsis dir: %v", err)
+	}
+	synopsisPath := filepath.Join(synopsisDir, "flight-desktop")
+	if err := os.WriteFile(synopsisPath, []byte("Access interactive desktop sessions"), 0o644); err != nil {
+		t.Fatalf("failed to write synopsis fixture: %v", err)
+	}
+	return root
+}

--- a/flight-web-suite/home_functional_test.go
+++ b/flight-web-suite/home_functional_test.go
@@ -58,8 +58,8 @@ func TestHomepageAuthenticated(t *testing.T) {
 	_, body := testutil.RenderPage(t, newApp(), http.MethodGet, "/", nil, http.StatusOK, testutil.WithSessionCookie("ben", config.Session.Secret))
 
 	assertAuthenticated(t, body, "ben")
-	assertToolCardPresentHTML(t, body, "Flight Desktop", "/assets/images/desktop.png", "Access interactive desktop sessions")
-	assertToolCardPresentHTML(t, body, "Flight Howto", "/assets/images/howto.png", "Learn about the Flight User Suite and using your cluster")
+	assertToolCardPresentHTML(t, body, "Flight Desktop", "/assets/images/desktop.png", "Access interactive desktop sessions", "/desktop")
+	assertToolCardPresentHTML(t, body, "Flight Howto", "/assets/images/howto.png", "Learn about the Flight User Suite and using your cluster", "/howto")
 }
 
 func TestHomepageAuthenticatedWithInvalidSessionCookie(t *testing.T) {
@@ -69,16 +69,17 @@ func TestHomepageAuthenticatedWithInvalidSessionCookie(t *testing.T) {
 	assertNotAuthenticated(t, body)
 }
 
-func assertToolCardPresentHTML(t *testing.T, body, title, imagePath, description string) {
+func assertToolCardPresentHTML(t *testing.T, body, title, imagePath, description, url string) {
 	t.Helper()
 
-	cardSelector := `div[data-testid="tool-card--` + title + `"]`
+	cardSelector := `a[data-testid="tool-card--` + title + `"]`
 	testutil.AssertSelection(t, body, cardSelector+` h2`, testutil.HasText(title))
 	testutil.AssertSelection(t, body, cardSelector+` p`, testutil.HasText(description))
 	testutil.AssertSelection(t, body, cardSelector+` img`,
 		testutil.HasAttr("src", imagePath),
 		testutil.HasAttr("alt", title+" logo"),
 	)
+	testutil.AssertSelection(t, body, cardSelector, testutil.HasAttr("href", url))
 }
 
 func assertToolCardAbsentHTML(t *testing.T, body, title string) {

--- a/flight-web-suite/main.go
+++ b/flight-web-suite/main.go
@@ -107,6 +107,7 @@ func newApp() *echo.Echo {
 		}
 		return c.Render(http.StatusOK, "home", AddCommonData(c, data))
 	})
+	e.GET("/desktop", indexDesktopSessionsHandler)
 	e.GET("/sessions", newSessionHandler)
 	e.POST("/sessions", createSessionHandler)
 	e.DELETE("/sessions", destroySessionHandler)

--- a/flight-web-suite/views/desktop/index.gohtml
+++ b/flight-web-suite/views/desktop/index.gohtml
@@ -1,0 +1,26 @@
+{{define "desktop/index"}}
+{{template "layouts.application.start" . }}
+
+<h1 class="mt-20 mb-6">Desktop Sessions</h1>
+<p class="mb-8" data-testid="desktop-sessions-summary">{{ .Summary }}</p>
+
+<div class="grid grid-cols-1 gap-4 xl:grid-cols-2 2xl:grid-cols-3" data-testid="desktop-session-cards">
+    {{range .DesktopSessions}}
+    <div class="border border-alces-blue-light p-6 text-left" data-testid="desktop-session-card--{{ .Name }}">
+        <h2 class="mb-3">{{ .Name }}</h2>
+        <dl class="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2">
+            <dt class="font-semibold">Desktop</dt>
+            <dd data-testid="desktop-session-desktop-type--{{ .Name }}">{{ .DesktopType }}</dd>
+            <dt class="font-semibold">State</dt>
+            <dd data-testid="desktop-session-state--{{ .Name }}">{{ .State }}</dd>
+            <dt class="font-semibold">Host</dt>
+            <dd data-testid="desktop-session-host--{{ .Name }}"><code class="text-fuchsia-700">{{ .Host }}</code></dd>
+            <dt class="font-semibold">Started</dt>
+            <dd data-testid="desktop-session-start-time--{{ .Name }}">{{ .StartTimeText }}</dd>
+        </dl>
+    </div>
+    {{end}}
+</div>
+
+{{template "layouts.application.end" . }}
+{{end}}

--- a/flight-web-suite/views/home.gohtml
+++ b/flight-web-suite/views/home.gohtml
@@ -10,18 +10,20 @@
         <p class="mb-8">Select a tool to access your cluster from within your browser.</p>
         <div class="flex flex-wrap justify-center gap-x-4" data-testid="tool-cards">
             {{range .Tools}}
-            <div class="
-            flex flex-col items-center gap-y-1 justify-center
-            border border-alces-blue-light
-            w-70 p-9 px-8
-            hover:shadow hover:border-alces-blue transition-colors duration-200 cursor-pointer group
-            " data-testid="tool-card--{{ .Name }}">
-                <div class="size-25 mb-2">
-                    <img src="{{ .IconPath }}" alt="{{ .Name }} logo" class="h-full">
+            <a href="{{ .URL }}" class="block no-underline text-inherit" data-testid="tool-card--{{ .Name }}">
+                <div class="
+                flex flex-col items-center gap-y-1 justify-center
+                border border-alces-blue-light
+                w-70 p-9 px-8
+                hover:shadow hover:border-alces-blue transition-colors duration-200 cursor-pointer group
+                ">
+                    <div class="size-25 mb-2">
+                        <img src="{{ .IconPath }}" alt="{{ .Name }} logo" class="h-full">
+                    </div>
+                    <h2 class="group-hover:text-alces-blue!">{{ .Name }}</h2>
+                    <p>{{ .Description }}</p>
                 </div>
-                <h2 class="group-hover:text-alces-blue!">{{ .Name }}</h2>
-                <p>{{ .Description }}</p>
-            </div>
+            </a>
             {{end}}
         </div>
     {{ else }}


### PR DESCRIPTION
This PR adds a page listing desktop sessions to web suite.

<img width="1049" height="859" alt="image" src="https://github.com/user-attachments/assets/8f9652be-8498-497a-abe8-b43d4aaeb889" />

The home page cards now link to the URL given in their definition.

The Flight Desktop card links to a new desktop page listing all of the user's desktop sessions.  The handler obtains the list of sessions by running the `flight-desktop` tool as the authenticated user in a sanitised environment.  If the user is not logged in, the page redirects to the login page. If the desktop tool is not enabled, the page returns a service unavailable response.

The `flight desktop list` command has learned a `--format FORMAT` flag. The valid values are `pretty` and `json`.  Web suite uses `--format json` when getting a list of sessions.

To facilitate branching on whether the desktop tool is enabled or not, the code for retrieving the tools has been extracted into the `flight-core/toolset` package.

### Known issues

* The link for the Flight Howto card is not yet implemented, so clicking that card will result in a 404.  This will be addressed in upcoming work.
* If redirected to the login page, the user is not redirected back once signed in.

---

This PR provides the mechanism for listing enabled tools that will be wanted in #134.  It is also likely to have a few merge conflicts with that branch.

Resolves #131 