### PR TITLE
Web suite can terminate local active desktops sessions

### DIFF
--- a/flight-desktop/main.go
+++ b/flight-desktop/main.go
@@ -44,6 +44,18 @@ func init() {
 	maxTextWidth = min(termWidth, 80)
 }
 
+var formatFlag = &cli.StringFlag{
+	Name:  "format",
+	Value: "pretty",
+	Usage: "use specified `FORMAT` for the output (pretty, json).",
+	Validator: func(format string) error {
+		if format != "pretty" && format != "json" {
+			return fmt.Errorf("%s is not a known format (pretty, json)", format)
+		}
+		return nil
+	},
+}
+
 func main() {
 	// Load config here rather than `init` to prevent errors from breaking
 	// tests.

--- a/flight-desktop/session_kill.go
+++ b/flight-desktop/session_kill.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 
 	"charm.land/log/v2"
 	"github.com/muesli/reflow/wordwrap"
@@ -19,11 +22,15 @@ func killSessionCommand() *cli.Command {
 		Arguments: []cli.Argument{
 			&cli.StringArg{Name: "name", UsageText: "<name>"},
 		},
+		Flags:         []cli.Flag{formatFlag},
 		Before:        assertArgPresent("name"),
 		ShellComplete: completeActiveSessionNames,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			name := cmd.StringArg("name")
 			session, err := loadSession(name)
+			if cmd.String("format") == "json" {
+				return killSessionJSON(ctx, session, err)
+			}
 			if err != nil {
 				if err2 := session.RemoveSessionDir(); err2 != nil {
 					log.Debug("Removing session dir", "sessionDir", session.sessionDir(), "err", err2)
@@ -55,6 +62,63 @@ func killSessionCommand() *cli.Command {
 			fmt.Printf("Desktop session '%s' has been terminated.\n", session.Name)
 			return nil
 		},
+	}
+}
+
+type terminationResponse struct {
+	Success     bool   `json:"success"`
+	SessionName string `json:"session_name"`
+	Error       string `json:"error,omitempty"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+func killSessionJSON(ctx context.Context, session *Session, loadErr error) error {
+	if loadErr != nil {
+		if _, ok := errors.AsType[UnknownSession](loadErr); ok {
+			return writeTerminationFailure(session.Name, loadErr.Error(), "not_found")
+		}
+		return writeTerminationFailure(session.Name, loadErr.Error(), "terminate_failed")
+	}
+	if !session.IsLocal() {
+		return writeTerminationFailure(session.Name, fmt.Sprintf("Desktop session '%s' is not local.", session.Name), "not_local")
+	}
+	if session.State != Active {
+		return writeTerminationFailure(session.Name, fmt.Sprintf("Desktop session '%s' is not active.", session.Name), "not_active")
+	}
+	if err := session.Kill(ctx); err != nil {
+		return writeTerminationFailure(session.Name, fmt.Sprintf("Terminating session '%s' failed.", session.Name), "terminate_failed")
+	}
+	return writeTerminationSuccess(session.Name)
+}
+
+func writeTerminationSuccess(sessionName string) error {
+	return writeTerminationResponse(terminationResponse{
+		Success:     true,
+		SessionName: sessionName,
+	}, 0)
+}
+
+func writeTerminationFailure(sessionName, message, reason string) error {
+	return writeTerminationResponse(terminationResponse{
+		Success:     false,
+		SessionName: sessionName,
+		Error:       message,
+		Reason:      reason,
+	}, 1)
+}
+
+func writeTerminationResponse(response terminationResponse, exitCode int) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(response); err != nil {
+		return err
+	}
+	if exitCode == 0 {
+		return nil
+	}
+	return SilentExitError{
+		ExitCode:  exitCode,
+		exitError: errors.New("session termination failed"),
 	}
 }
 

--- a/flight-desktop/session_kill_test.go
+++ b/flight-desktop/session_kill_test.go
@@ -1,0 +1,220 @@
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestKillSessionJSON(t *testing.T) {
+	tests := []struct {
+		name             string
+		sessionName      string
+		setup            func(t *testing.T)
+		expectedResponse map[string]any
+		expectedExitCode int
+	}{
+		{
+			name:        "success",
+			sessionName: "alpha",
+			setup: func(t *testing.T) {
+				proc := startTestProcess(t)
+				createDesktopSessionFixture(t, desktopSessionFixture{
+					Name:    "alpha",
+					IP:      "127.0.0.1",
+					Pid:     proc.Process.Pid,
+					State:   "active",
+					Host:    "localhost",
+					Display: "1",
+				})
+			},
+			expectedResponse: map[string]any{
+				"success":      true,
+				"session_name": "alpha",
+			},
+			expectedExitCode: 0,
+		},
+		{
+			name:        "not local",
+			sessionName: "beta",
+			setup: func(t *testing.T) {
+				proc := startTestProcess(t)
+				createDesktopSessionFixture(t, desktopSessionFixture{
+					Name:    "beta",
+					IP:      "192.0.2.10",
+					Pid:     proc.Process.Pid,
+					State:   "active",
+					Host:    "remote-host",
+					Display: "2",
+				})
+			},
+			expectedResponse: map[string]any{
+				"success":      false,
+				"session_name": "beta",
+				"error":        "Desktop session 'beta' is not local.",
+				"reason":       "not_local",
+			},
+			expectedExitCode: 1,
+		},
+		{
+			name:        "not active",
+			sessionName: "gamma",
+			setup: func(t *testing.T) {
+				createDesktopSessionFixture(t, desktopSessionFixture{
+					Name:    "gamma",
+					IP:      "127.0.0.1",
+					Pid:     999999,
+					State:   "active",
+					Host:    "localhost",
+					Display: "3",
+				})
+			},
+			expectedResponse: map[string]any{
+				"success":      false,
+				"session_name": "gamma",
+				"error":        "Desktop session 'gamma' is not active.",
+				"reason":       "not_active",
+			},
+			expectedExitCode: 1,
+		},
+		{
+			name:        "not found",
+			sessionName: "delta",
+			setup:       func(t *testing.T) {},
+			expectedResponse: map[string]any{
+				"success":      false,
+				"session_name": "delta",
+				"error":        "Unknown session: delta",
+				"reason":       "not_found",
+			},
+			expectedExitCode: 1,
+		},
+		{
+			name:        "terminate failed",
+			sessionName: "epsilon",
+			setup: func(t *testing.T) {
+				proc := startTestProcess(t)
+				createDesktopSessionFixture(t, desktopSessionFixture{
+					Name:    "epsilon",
+					IP:      "127.0.0.1",
+					Pid:     proc.Process.Pid,
+					State:   "active",
+					Host:    "localhost",
+					Display: "4",
+				})
+				overrideTestVNCServer(t, "#!/bin/sh\nexit 1\n")
+			},
+			expectedResponse: map[string]any{
+				"success":      false,
+				"session_name": "epsilon",
+				"error":        "Terminating session 'epsilon' failed.",
+				"reason":       "terminate_failed",
+			},
+			expectedExitCode: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup(t)
+
+			output, err := runBinary([]string{"kill", tt.sessionName, "--format", "json"}, nil)
+			assertExitCode(t, tt.expectedExitCode, output, err)
+
+			var got map[string]any
+			if err := json.NewDecoder(bytes.NewReader(output)).Decode(&got); err != nil {
+				t.Fatalf("failed to decode JSON output: %v\noutput: %s", err, output)
+			}
+
+			if len(got) != len(tt.expectedResponse) {
+				t.Fatalf("expected %d JSON fields, got %d: %#v", len(tt.expectedResponse), len(got), got)
+			}
+			for key, want := range tt.expectedResponse {
+				if got[key] != want {
+					t.Fatalf("expected %s=%v, got %v", key, want, got[key])
+				}
+			}
+		})
+	}
+}
+
+type desktopSessionFixture struct {
+	Name    string
+	IP      string
+	Pid     int
+	State   string
+	Host    string
+	Display string
+}
+
+func createDesktopSessionFixture(t *testing.T, session desktopSessionFixture) {
+	t.Helper()
+
+	sessionDir := filepath.Join(tmpDir, "local", "state", "flight", "desktop", "sessions", session.Name)
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		t.Fatalf("failed to create session dir: %v", err)
+	}
+
+	pidfile := filepath.Join(sessionDir, "vncserver.pid")
+	if err := os.WriteFile(pidfile, fmt.Appendf(nil, "%d\n", session.Pid), 0o600); err != nil {
+		t.Fatalf("failed to write pidfile: %v", err)
+	}
+
+	metadata := fmt.Sprintf(`session_type: xterm
+password: hunter2
+ip: %s
+state: %s
+created_at: %s
+metadata:
+  host: %s
+  display: "%s"
+  pidfile: %s
+`, session.IP, session.State, time.Date(2026, time.April, 22, 10, 0, 0, 0, time.UTC).Format(time.RFC3339), session.Host, session.Display, pidfile)
+
+	if err := os.WriteFile(filepath.Join(sessionDir, "metadata.yml"), []byte(metadata), 0o600); err != nil {
+		t.Fatalf("failed to write metadata: %v", err)
+	}
+}
+
+// We need a process running that can (1) be used to determine that a session
+// is active and not exited; and (2) be killed by the `kill` command. We create
+// such a process here.
+func startTestProcess(t *testing.T) *exec.Cmd {
+	t.Helper()
+
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start helper process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	return cmd
+}
+
+// overrideTestVNCServer overrides vncserver for a single test. This allows
+// control over whether the execution of it fails or not.  For instance, some
+// tests want to simulate a failure to kill a desktop session.
+func overrideTestVNCServer(t *testing.T, script string) {
+	t.Helper()
+
+	path := filepath.Join(flightRoot, "usr", "libexec", "desktop", "vncserver")
+	original, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read vncserver fixture: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.WriteFile(path, original, 0o755); err != nil {
+			t.Fatalf("failed to restore vncserver fixture: %v", err)
+		}
+	})
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to override vncserver fixture: %v", err)
+	}
+}

--- a/flight-desktop/session_list.go
+++ b/flight-desktop/session_list.go
@@ -20,19 +20,7 @@ func listSessionsCommand() *cli.Command {
 		Usage:       "List interactive desktop sessions",
 		Description: wordwrap.String("Display all known desktop sessions and their states.", 80),
 		Category:    "Sessions",
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:  "format",
-				Value: "pretty",
-				Usage: "output sessions in the specified `FORMAT` (pretty, json).",
-				Validator: func(format string) error {
-					if format != "pretty" && format != "json" {
-						return fmt.Errorf("%s is not a known format (pretty, json)", format)
-					}
-					return nil
-				},
-			},
-		},
+		Flags:       []cli.Flag{formatFlag},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			sessions, err := loadAllSessions()
 			if err != nil {

--- a/flight-desktop/session_start.go
+++ b/flight-desktop/session_start.go
@@ -17,7 +17,7 @@ import (
 var (
 	nameWhitelist            = "-_.A-Za-z0-9"
 	nameWhitelistExplanation = "letters, numbers, hyphens, underscores and dots"
-	nameBlacklist            = regexp.MustCompile(fmt.Sprintf("[^%s]+", nameWhitelist))
+	nameBlacklist            = regexp.MustCompile(fmt.Sprintf("^-|[^%s]+", nameWhitelist))
 	nameMaxLen               = 40
 )
 
@@ -39,7 +39,7 @@ func startSessionCommand() *cli.Command {
 				DefaultText: "random",
 				Validator: func(name string) error {
 					if nameBlacklist.MatchString(name) {
-						return fmt.Errorf("it can contain only %s.", nameWhitelistExplanation)
+						return fmt.Errorf("it can contain only %s and cannot start with a hyphen.", nameWhitelistExplanation)
 					}
 					if len(name) > nameMaxLen {
 						return fmt.Errorf("it must be no more than %d characters", nameMaxLen)

--- a/flight-desktop/testdata/golden/kill-help.golden
+++ b/flight-desktop/testdata/golden/kill-help.golden
@@ -14,7 +14,8 @@ DESCRIPTION:
    list' to see a list of your sessions.
 
 OPTIONS:
-   --help, -h  show help
+   --format FORMAT  use specified FORMAT for the output (pretty, json). (default: "pretty")
+   --help, -h       show help
 
 GLOBAL OPTIONS:
    --log-level LEVEL  set the log LEVEL (debug, info, warn, error, fatal). Default: warn

--- a/flight-desktop/testdata/golden/list-help.golden
+++ b/flight-desktop/testdata/golden/list-help.golden
@@ -11,7 +11,7 @@ DESCRIPTION:
    Display all known desktop sessions and their states.
 
 OPTIONS:
-   --format FORMAT  output sessions in the specified FORMAT (pretty, json). (default: "pretty")
+   --format FORMAT  use specified FORMAT for the output (pretty, json). (default: "pretty")
    --help, -h       show help
 
 GLOBAL OPTIONS:

--- a/flight-web-suite/desktop_sessions.go
+++ b/flight-web-suite/desktop_sessions.go
@@ -34,6 +34,9 @@ type desktopSessionCard struct {
 	State         string
 	Host          string
 	StartTimeText string
+	ActionLabel   string
+	ActionTitle   string
+	ActionEnabled bool
 }
 
 func indexDesktopSessionsHandler(c *echo.Context) error {
@@ -46,7 +49,7 @@ func indexDesktopSessionsHandler(c *echo.Context) error {
 		return echo.NewHTTPError(http.StatusServiceUnavailable, "Flight Desktop is not enabled")
 	}
 
-	sessions, err := listDesktopSessions(c.Request().Context(), CurrentUserName(c))
+	sessions, err := desktopListCommand(c.Request().Context(), CurrentUserName(c))
 	if err != nil {
 		return err
 	}
@@ -65,15 +68,59 @@ func indexDesktopSessionsHandler(c *echo.Context) error {
 	return c.Render(http.StatusOK, "desktop/index", AddCommonData(c, data))
 }
 
+func destroyDesktopSessionHandler(c *echo.Context) error {
+	if !IsLoggedIn(c) {
+		return c.Redirect(http.StatusSeeOther, "/sessions")
+	}
+
+	tool, err := toolset.GetTool(env.FlightRoot, "desktop")
+	if err != nil || !tool.Enabled {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "Flight Desktop is not enabled")
+	}
+
+	response, err := desktopKillCommand(c.Request().Context(), CurrentUserName(c), c.Param("sessionName"))
+	if err != nil {
+		return err
+	}
+
+	sess, err := GetSession(c)
+	if err != nil {
+		return err
+	}
+	if response.Success {
+		sess.AddFlash(fmt.Sprintf("Desktop session '%s' terminated.", response.SessionName), "notice")
+	} else {
+		sess.AddFlash(fmt.Sprintf("Failed to terminate desktop session '%s': %s", response.SessionName, response.Error), "alert")
+	}
+	SaveSession(c, sess)
+	return c.Redirect(http.StatusSeeOther, "/desktop")
+}
+
 func buildDesktopSessionCards(sessions []desktopSession) []desktopSessionCard {
 	cards := make([]desktopSessionCard, 0, len(sessions))
 	for _, session := range sessions {
+		actionLabel := "Clean"
+		actionTitle := "Cleaning desktop sessions is not yet implemented."
+		actionEnabled := false
+		switch session.State {
+		case "active":
+			actionLabel = "Terminate"
+			actionTitle = ""
+			actionEnabled = true
+		case "remote":
+			actionLabel = "Terminate"
+			actionTitle = "Termination of remote sessions is not yet implemented."
+		}
+
 		cards = append(cards, desktopSessionCard{
 			Name:          session.Name,
 			DesktopType:   session.DesktopType,
 			State:         session.State,
 			Host:          session.Host,
 			StartTimeText: session.CreatedAt.Format("Mon 2 Jan 2006 15:04"),
+			ActionLabel:   actionLabel,
+			ActionTitle:   actionTitle,
+			ActionEnabled: actionEnabled,
 		})
 	}
 	return cards
@@ -113,13 +160,8 @@ func desktopSessionsSummary(sessions []desktopSession) string {
 	return fmt.Sprintf("You have %d desktop sessions currently running %s", runningCount, nonRunningString)
 }
 
-func listDesktopSessions(ctx context.Context, username string) ([]desktopSession, error) {
-	userInfo, err := user.Lookup(username)
-	if err != nil {
-		return nil, fmt.Errorf("looking up user %q: %w", username, err)
-	}
-
-	cmd, err := desktopListCommand(ctx, userInfo)
+func desktopListCommand(ctx context.Context, username string) ([]desktopSession, error) {
+	cmd, err := buildDesktopCommand(ctx, username, "list", "--format", "json")
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +184,45 @@ func listDesktopSessions(ctx context.Context, username string) ([]desktopSession
 	return sessions, nil
 }
 
-func desktopListCommand(ctx context.Context, userInfo *user.User) (*exec.Cmd, error) {
+type terminationResponse struct {
+	Success     bool   `json:"success"`
+	SessionName string `json:"session_name"`
+	Error       string `json:"error"`
+	Reason      string `json:"reason"`
+}
+
+func desktopKillCommand(ctx context.Context, username, sessionName string) (terminationResponse, error) {
+	cmd, err := buildDesktopCommand(ctx, username, "kill", sessionName, "--format", "json")
+	if err != nil {
+		return terminationResponse{}, err
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	var response terminationResponse
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &response); decodeErr == nil {
+		return response, nil
+	}
+
+	if runErr != nil {
+		if stderr.Len() != 0 {
+			return terminationResponse{}, fmt.Errorf("terminating desktop session: %s", stderr.String())
+		}
+		return terminationResponse{}, fmt.Errorf("terminating desktop session: %w", runErr)
+	}
+	return terminationResponse{}, fmt.Errorf("decoding desktop termination response: %s", stdout.String())
+}
+
+func buildDesktopCommand(ctx context.Context, username string, args ...string) (*exec.Cmd, error) {
+	userInfo, err := user.Lookup(username)
+	if err != nil {
+		return nil, fmt.Errorf("looking up user %q: %w", username, err)
+	}
+
 	uid, err := strconv.Atoi(userInfo.Uid)
 	if err != nil {
 		return nil, fmt.Errorf("parsing uid for user %q: %w", userInfo.Username, err)
@@ -165,7 +245,7 @@ func desktopListCommand(ctx context.Context, userInfo *user.User) (*exec.Cmd, er
 		groups = append(groups, uint32(parsed))
 	}
 
-	cmd := exec.CommandContext(ctx, desktopToolPath(), "list", "--format", "json")
+	cmd := exec.CommandContext(ctx, desktopToolPath(), args...)
 	cmd.Dir = userInfo.HomeDir
 	cmd.Env = desktopCommandEnv(userInfo)
 	if os.Geteuid() == 0 {

--- a/flight-web-suite/desktop_sessions.go
+++ b/flight-web-suite/desktop_sessions.go
@@ -192,7 +192,7 @@ type terminationResponse struct {
 }
 
 func desktopKillCommand(ctx context.Context, username, sessionName string) (terminationResponse, error) {
-	cmd, err := buildDesktopCommand(ctx, username, "kill", sessionName, "--format", "json")
+	cmd, err := buildDesktopCommand(ctx, username, "kill", "--format", "json", "--", sessionName)
 	if err != nil {
 		return terminationResponse{}, err
 	}

--- a/flight-web-suite/desktop_sessions_functional_test.go
+++ b/flight-web-suite/desktop_sessions_functional_test.go
@@ -157,7 +157,7 @@ JSON
 	if err != nil {
 		t.Fatalf("failed to read command args fixture: %v", err)
 	}
-	if got := strings.TrimSpace(string(data)); got != "kill\nalpha\n--format\njson" {
+	if got := strings.TrimSpace(string(data)); got != "kill\n--format\njson\n--\nalpha" {
 		t.Fatalf("expected kill command args, got %q", got)
 	}
 }

--- a/flight-web-suite/desktop_sessions_functional_test.go
+++ b/flight-web-suite/desktop_sessions_functional_test.go
@@ -63,8 +63,19 @@ JSON
 	testutil.AssertSelection(t, body, `[data-testid="desktop-session-start-time--alpha"]`,
 		testutil.HasText("Mon 20 Apr 2026 10:00"),
 	)
+	testutil.AssertSelection(t, body, `[data-testid="desktop-session-action-button--alpha"]`,
+		testutil.HasText("Terminate"),
+	)
+	testutil.AssertSelection(t, body, `form[action="/desktop/alpha"] input[name="_method"]`,
+		testutil.HasAttr("value", "DELETE"),
+	)
 	testutil.AssertSelection(t, body, `[data-testid="desktop-session-card--beta"] h2`,
 		testutil.HasText("beta"),
+	)
+	testutil.AssertSelection(t, body, `[data-testid="desktop-session-action-button--beta"]`,
+		testutil.HasText("Clean"),
+		testutil.HasAttr("disabled", ""),
+		testutil.HasAttr("title", "Cleaning desktop sessions is not yet implemented."),
 	)
 }
 
@@ -78,6 +89,76 @@ echo '[]'
 
 	if want := "Flight Desktop is not enabled"; !strings.Contains(body, want) {
 		t.Fatalf("expected body to contain %q, got %q", want, body)
+	}
+}
+
+func TestDesktopSessionsPageShowsRemoteActionAsDisabledTerminate(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+cat <<'JSON'
+[
+  {
+    "name": "remote-a",
+    "desktop_type": "Gnome",
+    "state": "remote",
+    "host": "remote-host",
+    "created_at": "2026-04-20T10:00:00Z"
+  }
+]
+JSON
+`))
+
+	_, body := testutil.RenderPage(t, newApp(), http.MethodGet, "/desktop", nil, http.StatusOK, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	testutil.AssertSelection(t, body, `[data-testid="desktop-session-action-button--remote-a"]`,
+		testutil.HasText("Terminate"),
+		testutil.HasAttr("disabled", ""),
+		testutil.HasAttr("title", "Termination of remote sessions is not yet implemented."),
+	)
+}
+
+func TestDestroyDesktopSessionRedirectsForAnonymous(t *testing.T) {
+	resp, _ := testutil.RenderPage(t, newApp(), http.MethodDelete, "/desktop/alpha", nil, http.StatusSeeOther)
+
+	if resp.Header.Get("location") != "/sessions" {
+		t.Errorf("expected desktop termination to redirect to '/sessions' for anonymous users")
+	}
+}
+
+func TestDestroyDesktopSessionReturnsServiceUnavailableWhenToolDisabled(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o644, `#!/bin/sh
+echo '[]'
+`))
+
+	_, body := testutil.RenderPage(t, newApp(), http.MethodDelete, "/desktop/alpha", nil, http.StatusServiceUnavailable, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	if want := "Flight Desktop is not enabled"; !strings.Contains(body, want) {
+		t.Fatalf("expected body to contain %q, got %q", want, body)
+	}
+}
+
+func TestDestroyDesktopSessionInvokesKillWithJSONFormat(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	argsFile := filepath.Join(t.TempDir(), "desktop-args.txt")
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+printf '%s\n' "$@" > "`+argsFile+`"
+cat <<'JSON'
+{
+  "success": true,
+  "session_name": "alpha"
+}
+JSON
+`))
+
+	testutil.RenderPage(t, newApp(), http.MethodDelete, "/desktop/alpha", nil, http.StatusSeeOther, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("failed to read command args fixture: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "kill\nalpha\n--format\njson" {
+		t.Fatalf("expected kill command args, got %q", got)
 	}
 }
 

--- a/flight-web-suite/desktop_sessions_integration_test.go
+++ b/flight-web-suite/desktop_sessions_integration_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/concertim/flight-user-suite/flight-web-suite/internal/testutil"
+)
+
+func TestDestroyDesktopSessionSuccessAddsFlashAndRedirects(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setAuthenticatorPathForTest(t, filepath.Join("testdata", "authenticator_success.sh"))
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+if [ "$1" = "list" ]; then
+  echo '[]'
+  exit 0
+fi
+cat <<'JSON'
+{
+  "success": true,
+  "session_name": "alpha"
+}
+JSON
+`))
+
+	srv, client := testutil.SetupIntegrationServer(t, newApp())
+	client.PostForm(srv.URL+"/sessions", url.Values{
+		"username": {currentUser.Username},
+		"password": {"fakepassword"},
+	})
+	client.FollowRedirect()
+	client.PostForm(srv.URL+"/desktop/alpha", url.Values{
+		"_method": {"DELETE"},
+	})
+
+	client.AssertRedirect(t, http.StatusSeeOther, "/desktop")
+	_, body := client.FollowRedirect()
+	testutil.AssertSelection(t, body, `div.flash.notice`,
+		testutil.HasText("Desktop session 'alpha' terminated."),
+	)
+}
+
+func TestDestroyDesktopSessionFailureAddsFlashAndRedirects(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setAuthenticatorPathForTest(t, filepath.Join("testdata", "authenticator_success.sh"))
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+if [ "$1" = "list" ]; then
+  echo '[]'
+  exit 0
+fi
+cat <<'JSON'
+{
+  "success": false,
+  "session_name": "alpha",
+  "error": "Desktop session 'alpha' is not active.",
+  "reason": "not_active"
+}
+JSON
+exit 1
+`))
+
+	srv, client := testutil.SetupIntegrationServer(t, newApp())
+	client.PostForm(srv.URL+"/sessions", url.Values{
+		"username": {currentUser.Username},
+		"password": {"fakepassword"},
+	})
+	client.FollowRedirect()
+	client.PostForm(srv.URL+"/desktop/alpha", url.Values{
+		"_method": {"DELETE"},
+	})
+
+	client.AssertRedirect(t, http.StatusSeeOther, "/desktop")
+	_, body := client.FollowRedirect()
+	testutil.AssertSelection(t, body, `div.flash.alert`,
+		testutil.HasText("Failed to terminate desktop session 'alpha': Desktop session 'alpha' is not active."),
+	)
+}

--- a/flight-web-suite/main.go
+++ b/flight-web-suite/main.go
@@ -108,6 +108,7 @@ func newApp() *echo.Echo {
 		return c.Render(http.StatusOK, "home", AddCommonData(c, data))
 	})
 	e.GET("/desktop", indexDesktopSessionsHandler)
+	e.DELETE("/desktop/:sessionName", destroyDesktopSessionHandler)
 	e.GET("/sessions", newSessionHandler)
 	e.POST("/sessions", createSessionHandler)
 	e.DELETE("/sessions", destroySessionHandler)

--- a/flight-web-suite/views/desktop/index.gohtml
+++ b/flight-web-suite/views/desktop/index.gohtml
@@ -7,7 +7,25 @@
 <div class="grid grid-cols-1 gap-4 xl:grid-cols-2 2xl:grid-cols-3" data-testid="desktop-session-cards">
     {{range .DesktopSessions}}
     <div class="border border-alces-blue-light p-6 text-left" data-testid="desktop-session-card--{{ .Name }}">
-        <h2 class="mb-3">{{ .Name }}</h2>
+        <div class="mb-3 flex items-start justify-between gap-4">
+            <h2>{{ .Name }}</h2>
+            <details class="relative" data-testid="desktop-session-actions--{{ .Name }}">
+                <summary class="cursor-pointer list-none" aria-label="Session actions">☰</summary>
+                <div class="absolute top-6 right-0 z-10 min-w-32 border border-alces-blue-light bg-white p-2 shadow-md">
+                    {{if .ActionEnabled}}
+                    <form action="/desktop/{{ .Name }}" method="post">
+                        <input type="hidden" name="_method" value="DELETE">
+                        <button class="w-full cursor-pointer text-left" type="submit"
+                            data-testid="desktop-session-action-button--{{ .Name }}">{{ .ActionLabel }}</button>
+                    </form>
+                    {{else}}
+                    <button class="w-full cursor-not-allowed text-left text-gray-500" type="button" disabled
+                        title="{{ .ActionTitle }}" data-testid="desktop-session-action-button--{{ .Name }}">{{
+                        .ActionLabel }}</button>
+                    {{end}}
+                </div>
+            </details>
+        </div>
         <dl class="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2">
             <dt class="font-semibold">Desktop</dt>
             <dd data-testid="desktop-session-desktop-type--{{ .Name }}">{{ .DesktopType }}</dd>


### PR DESCRIPTION
This PR adds support for terminating local active desktop sessions.

<img width="1017" height="612" alt="image" src="https://github.com/user-attachments/assets/4369d7f9-d2f3-4f4e-90d7-6d17d5a587bd" />

Active sessions have a "Terminate" entry.

<img width="503" height="234" alt="image" src="https://github.com/user-attachments/assets/6dc25e73-9872-4197-8e80-6da7fb2ace35" />

Clicking on it reloads the page and displays a success (or failure) flash.

<img width="1226" height="700" alt="image" src="https://github.com/user-attachments/assets/a407f20c-4c0c-4398-a4c2-e067801265e3" />

Termination of remote desktop sessions is not yet implemented.

<img width="1017" height="612" alt="image" src="https://github.com/user-attachments/assets/d96bc0a0-325f-4d29-ab24-81e2ec728390" />

Cleaning up of stale (exited or broken) sessions is likewise not-yet implemented.

<img width="1022" height="700" alt="image" src="https://github.com/user-attachments/assets/ea34055b-6bbd-487a-a851-28b3ab3e6863" />

### Implementation

The `desktop kill` command has learned a new `--format FORMAT` flag.  This is similar to the flag for the `list` command.  It has two valid values `json` and `pretty`. The default is `pretty` and provides the existing behaviour. The `json` format is intended for consumption by other parts of FUS.

Executing `desktop kill` is largely similar to executing `desktop list`. Some minor refactoring has been done to provide a common way to run the `flight-desktop` executable. 

Finally, a change has been made to the format of permitted desktop session names.  Previously, `--foo` was a valid desktop name.  Allowing desktop names to begin with `-` (or `--`) means that care needs to be taken to avoid `flight-desktop` parsing them as arguments.  Web suite takes care to avoid that, but I've also changed the validation on session names to prevent names from starting with `-`.  I can't see this causing any issues and makes the lives of CLI users of `flight-desktop` easier.

### Known issues and missing features

The implementation of the dropdown menu leaves a lot to be desired. Its main advantage is that it was simple to implement and doesn't require javascript.  Eventually, we'll want to have javascript included, but that is outside the scope of this PR.

Termination of remote desktop sessions is not yet implemented.

Cleaning up of exited or broken sessions is not yet implemented.