### PR TITLE
Flight Web can launch local desktop sessions

### DIFF
--- a/flight-desktop/integration_test.go
+++ b/flight-desktop/integration_test.go
@@ -1,6 +1,8 @@
 package main_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -24,6 +26,19 @@ var testdataPath = ""
 var tmpDir = ""
 var flightRoot = ""
 var flightStateRoot = ""
+
+type availableTypeResponse struct {
+	ID      string `json:"id"`
+	Summary string `json:"summary"`
+	URL     string `json:"url"`
+}
+
+type startCommandResponse struct {
+	Success     bool   `json:"success"`
+	SessionName string `json:"session_name"`
+	Error       string `json:"error"`
+	Reason      string `json:"reason"`
+}
 
 // Setup/teardown logic for running all tests in the package.
 func TestMain(m *testing.M) {
@@ -230,6 +245,162 @@ func Test_session_life_cycle(t *testing.T) {
 	}
 }
 
+func Test_avail_json(t *testing.T) {
+	output, err := runBinary([]string{"avail", "--format", "json"}, nil)
+	assertExitCode(t, 0, output, err)
+
+	var response []availableTypeResponse
+	if err := json.Unmarshal(jsonPayload(t, output), &response); err != nil {
+		t.Fatalf("failed to decode avail json: %v\noutput:\n%s", err, output)
+	}
+
+	if len(response) != 2 {
+		t.Fatalf("expected 2 desktop types, got %d", len(response))
+	}
+	if response[0].ID != "gnome" || response[1].ID != "xterm" {
+		t.Fatalf("expected types to be ordered by id, got %#v", response)
+	}
+}
+
+func Test_avail_json_empty(t *testing.T) {
+	typesDir := filepath.Join(flightRoot, "usr", "lib", "desktop", "types")
+	backupDir := filepath.Join(flightRoot, "usr", "lib", "desktop", "types-backup")
+	if err := os.Rename(typesDir, backupDir); err != nil {
+		t.Fatalf("failed to move types dir aside: %v", err)
+	}
+	if err := os.MkdirAll(typesDir, 0o755); err != nil {
+		t.Fatalf("failed to create empty types dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(typesDir)
+		_ = os.Rename(backupDir, typesDir)
+	})
+
+	output, err := runBinary([]string{"avail", "--format", "json"}, nil)
+	assertExitCode(t, 0, output, err)
+
+	var response []availableTypeResponse
+	if err := json.Unmarshal(jsonPayload(t, output), &response); err != nil {
+		t.Fatalf("failed to decode avail json: %v\noutput:\n%s", err, output)
+	}
+	if len(response) != 0 {
+		t.Fatalf("expected empty desktop type list, got %#v", response)
+	}
+}
+
+func Test_start_json(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		setup           func(t *testing.T)
+		wantExitCode    int
+		wantSuccess     bool
+		wantSessionName string
+		wantReason      string
+		wantNamePrefix  string // We're using the "meaningless" name generator so prefix is correct.
+	}{
+		{
+			name:            "success with explicit name",
+			args:            []string{"start", "xterm", "--name", "my-session", "--format", "json"},
+			wantExitCode:    0,
+			wantSuccess:     true,
+			wantSessionName: "my-session",
+		},
+		{
+			name:           "success with generated name",
+			args:           []string{"start", "xterm", "--format", "json"},
+			wantExitCode:   0,
+			wantSuccess:    true,
+			wantNamePrefix: "xterm.",
+		},
+		{
+			name:            "invalid type",
+			args:            []string{"start", "missing", "--format", "json"},
+			wantExitCode:    1,
+			wantSuccess:     false,
+			wantSessionName: "",
+			wantReason:      "invalid_type",
+		},
+		{
+			name:            "invalid name",
+			args:            []string{"start", "xterm", "--name", "bad name", "--format", "json"},
+			wantExitCode:    1,
+			wantSuccess:     false,
+			wantSessionName: "bad name",
+			wantReason:      "invalid_name",
+		},
+		{
+			name:            "invalid geometry",
+			args:            []string{"start", "xterm", "--geometry", "1024", "--name", "bad-geometry", "--format", "json"},
+			wantExitCode:    1,
+			wantSuccess:     false,
+			wantSessionName: "bad-geometry",
+			wantReason:      "invalid_geometry",
+		},
+		{
+			name:            "dependency failure",
+			args:            []string{"start", "gnome", "--name", "my-gnome", "--format", "json"},
+			wantExitCode:    1,
+			wantSuccess:     false,
+			wantSessionName: "my-gnome",
+			wantReason:      "dependencies_failed",
+		},
+		{
+			name: "session start failure",
+			args: []string{"start", "xterm", "--name", "broken-session", "--format", "json"},
+			setup: func(t *testing.T) {
+				path := filepath.Join(flightRoot, "usr", "libexec", "desktop", "vncserver")
+				original, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("failed to read vncserver fixture: %v", err)
+				}
+				replacement := []byte("#!/bin/sh\nexit 1\n")
+				if err := os.WriteFile(path, replacement, 0o755); err != nil {
+					t.Fatalf("failed to replace vncserver fixture: %v", err)
+				}
+				t.Cleanup(func() {
+					_ = os.WriteFile(path, original, 0o755)
+				})
+			},
+			wantExitCode:    1,
+			wantSuccess:     false,
+			wantSessionName: "broken-session",
+			wantReason:      "start_failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup(t)
+			}
+
+			output, err := runBinary(tt.args, nil)
+			assertExitCode(t, tt.wantExitCode, output, err)
+
+			var response startCommandResponse
+			if err := json.Unmarshal(jsonPayload(t, output), &response); err != nil {
+				t.Fatalf("failed to decode start json: %v\noutput:\n%s", err, output)
+			}
+
+			if response.Success != tt.wantSuccess {
+				t.Fatalf("expected success=%t, got %#v", tt.wantSuccess, response)
+			}
+			if tt.wantSessionName != "" || response.SessionName == "" {
+				if response.SessionName != tt.wantSessionName {
+					t.Fatalf("expected session name %q, got %#v", tt.wantSessionName, response)
+				}
+			}
+			if tt.wantNamePrefix != "" && !strings.HasPrefix(response.SessionName, tt.wantNamePrefix) {
+				t.Fatalf("expected session name to start with %q, got %#v", tt.wantNamePrefix, response)
+			}
+			if response.Reason != tt.wantReason {
+				t.Fatalf("expected reason %q, got %#v", tt.wantReason, response)
+			}
+		})
+	}
+}
+
 func fixturePath(fixture string) string {
 	return filepath.Join(testdataPath, fixture)
 }
@@ -300,6 +471,23 @@ func assertOutputContains(t *testing.T, expectedLine string, output []byte) {
 		t.Logf("expected output to contain '%s'\n  got\n%s", expectedLine, actual)
 		t.FailNow()
 	}
+}
+
+func jsonPayload(t *testing.T, output []byte) []byte {
+	t.Helper()
+
+	trimmed := bytes.TrimSpace(output)
+	if len(trimmed) == 0 {
+		t.Fatal("expected JSON output, got empty output")
+	}
+
+	lastObject := bytes.LastIndexByte(trimmed, '}')
+	lastArray := bytes.LastIndexByte(trimmed, ']')
+	last := max(lastObject, lastArray)
+	if last == -1 {
+		t.Fatalf("expected JSON payload, got %q", trimmed)
+	}
+	return trimmed[:last+1]
 }
 
 func createTempDir(prefix string) string {

--- a/flight-desktop/integration_test.go
+++ b/flight-desktop/integration_test.go
@@ -33,11 +33,29 @@ type availableTypeResponse struct {
 	URL     string `json:"url"`
 }
 
-type startCommandResponse struct {
-	Success     bool   `json:"success"`
+type startCommandSuccessResponse struct {
+	Success     *bool  `json:"success"`
 	SessionName string `json:"session_name"`
-	Error       string `json:"error"`
-	Reason      string `json:"reason"`
+}
+
+type startCommandErrorResponse struct {
+	Errors []startCommandError `json:"errors"`
+}
+
+type startCommandError struct {
+	Code   string                   `json:"code"`
+	Title  string                   `json:"title"`
+	Detail string                   `json:"detail"`
+	Source *startCommandErrorSource `json:"source,omitempty"`
+	Meta   startCommandErrorMeta    `json:"meta"`
+}
+
+type startCommandErrorSource struct {
+	Parameter string `json:"parameter"`
+}
+
+type startCommandErrorMeta struct {
+	CLIDetail string `json:"cli_detail"`
 }
 
 // Setup/teardown logic for running all tests in the package.
@@ -144,6 +162,8 @@ func Test_golden_tests(t *testing.T) {
 }
 
 func Test_session_start_artefacts(t *testing.T) {
+	resetDesktopSessionState(t)
+
 	args := []string{"start", "xterm", "--name", "my-session"}
 	output, err := runBinary(args, nil)
 	assertExitCode(t, 0, output, err)
@@ -174,6 +194,8 @@ func Test_session_start_artefacts(t *testing.T) {
 }
 
 func Test_session_life_cycle(t *testing.T) {
+	resetDesktopSessionState(t)
+
 	tests := []struct {
 		testName         string
 		optionsAndArgs   []string
@@ -298,6 +320,9 @@ func Test_start_json(t *testing.T) {
 		wantSessionName string
 		wantReason      string
 		wantNamePrefix  string // We're using the "meaningless" name generator so prefix is correct.
+		wantError       string
+		wantCLIDetail   string
+		wantParameter   string
 	}{
 		{
 			name:            "success with explicit name",
@@ -320,30 +345,41 @@ func Test_start_json(t *testing.T) {
 			wantSuccess:     false,
 			wantSessionName: "",
 			wantReason:      "invalid_type",
+			wantError:       "Unknown desktop type 'missing'. Valid values are gnome, xterm.",
+			wantCLIDetail:   "unknown type 'missing'. Valid values are gnome, xterm.",
+			wantParameter:   "type",
 		},
 		{
 			name:            "invalid name",
 			args:            []string{"start", "xterm", "--name", "bad name", "--format", "json"},
 			wantExitCode:    1,
 			wantSuccess:     false,
-			wantSessionName: "bad name",
+			wantSessionName: "",
 			wantReason:      "invalid_name",
+			wantError:       "Session name can contain only letters, numbers, hyphens, underscores and dots and cannot start with a hyphen.",
+			wantCLIDetail:   "invalid value \"bad name\" for flag -name: it can contain only letters, numbers, hyphens, underscores and dots and cannot start with a hyphen.",
+			wantParameter:   "name",
 		},
 		{
 			name:            "invalid geometry",
 			args:            []string{"start", "xterm", "--geometry", "1024", "--name", "bad-geometry", "--format", "json"},
 			wantExitCode:    1,
 			wantSuccess:     false,
-			wantSessionName: "bad-geometry",
+			wantSessionName: "",
 			wantReason:      "invalid_geometry",
+			wantError:       "Desktop geometry must be in WIDTHxHEIGHT format with positive integers.",
+			wantCLIDetail:   "invalid value \"1024\" for flag -geometry: it must be in WIDTHxHEIGHT format with positive integers",
+			wantParameter:   "geometry",
 		},
 		{
 			name:            "dependency failure",
 			args:            []string{"start", "gnome", "--name", "my-gnome", "--format", "json"},
 			wantExitCode:    1,
 			wantSuccess:     false,
-			wantSessionName: "my-gnome",
+			wantSessionName: "",
 			wantReason:      "dependencies_failed",
+			wantError:       "Missing required dependencies for gnome desktop type.",
+			wantCLIDetail:   "Missing required dependencies for gnome desktop type.",
 		},
 		{
 			name: "session start failure",
@@ -364,13 +400,41 @@ func Test_start_json(t *testing.T) {
 			},
 			wantExitCode:    1,
 			wantSuccess:     false,
-			wantSessionName: "broken-session",
+			wantSessionName: "",
 			wantReason:      "start_failed",
+			wantError:       "Starting desktop session 'broken-session' failed.",
+			wantCLIDetail:   "staring VNC server: exit status 1",
+		},
+		{
+			name: "session start failure with generated name",
+			args: []string{"start", "xterm", "--format", "json"},
+			setup: func(t *testing.T) {
+				path := filepath.Join(flightRoot, "usr", "libexec", "desktop", "vncserver")
+				original, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("failed to read vncserver fixture: %v", err)
+				}
+				replacement := []byte("#!/bin/sh\nexit 1\n")
+				if err := os.WriteFile(path, replacement, 0o755); err != nil {
+					t.Fatalf("failed to replace vncserver fixture: %v", err)
+				}
+				t.Cleanup(func() {
+					_ = os.WriteFile(path, original, 0o755)
+				})
+			},
+			wantExitCode:    1,
+			wantSuccess:     false,
+			wantSessionName: "",
+			wantReason:      "start_failed",
+			wantError:       "Starting desktop session failed.",
+			wantCLIDetail:   "staring VNC server: exit status 1",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			resetDesktopSessionState(t)
+
 			if tt.setup != nil {
 				tt.setup(t)
 			}
@@ -378,24 +442,53 @@ func Test_start_json(t *testing.T) {
 			output, err := runBinary(tt.args, nil)
 			assertExitCode(t, tt.wantExitCode, output, err)
 
-			var response startCommandResponse
-			if err := json.Unmarshal(jsonPayload(t, output), &response); err != nil {
+			payload := jsonPayload(t, output)
+
+			var successResponse startCommandSuccessResponse
+			if err := json.Unmarshal(payload, &successResponse); err != nil {
 				t.Fatalf("failed to decode start json: %v\noutput:\n%s", err, output)
 			}
 
-			if response.Success != tt.wantSuccess {
-				t.Fatalf("expected success=%t, got %#v", tt.wantSuccess, response)
-			}
-			if tt.wantSessionName != "" || response.SessionName == "" {
-				if response.SessionName != tt.wantSessionName {
-					t.Fatalf("expected session name %q, got %#v", tt.wantSessionName, response)
+			if tt.wantSuccess {
+				if successResponse.Success == nil || *successResponse.Success != tt.wantSuccess {
+					t.Fatalf("expected success=%t, got %#v", tt.wantSuccess, successResponse)
 				}
+				if tt.wantSessionName != "" || successResponse.SessionName == "" {
+					if successResponse.SessionName != tt.wantSessionName {
+						t.Fatalf("expected session name %q, got %#v", tt.wantSessionName, successResponse)
+					}
+				}
+				if tt.wantNamePrefix != "" && !strings.HasPrefix(successResponse.SessionName, tt.wantNamePrefix) {
+					t.Fatalf("expected session name to start with %q, got %#v", tt.wantNamePrefix, successResponse)
+				}
+				return
 			}
-			if tt.wantNamePrefix != "" && !strings.HasPrefix(response.SessionName, tt.wantNamePrefix) {
-				t.Fatalf("expected session name to start with %q, got %#v", tt.wantNamePrefix, response)
+
+			var errorResponse startCommandErrorResponse
+			if err := json.Unmarshal(payload, &errorResponse); err != nil {
+				t.Fatalf("failed to decode start error json: %v\noutput:\n%s", err, output)
 			}
-			if response.Reason != tt.wantReason {
-				t.Fatalf("expected reason %q, got %#v", tt.wantReason, response)
+			if len(errorResponse.Errors) != 1 {
+				t.Fatalf("expected exactly one error, got %#v", errorResponse)
+			}
+			startErr := errorResponse.Errors[0]
+			if startErr.Code != tt.wantReason {
+				t.Fatalf("expected reason %q, got %#v", tt.wantReason, startErr)
+			}
+			if tt.wantError != "" && startErr.Detail != tt.wantError {
+				t.Fatalf("expected error %q, got %#v", tt.wantError, startErr)
+			}
+			if tt.wantCLIDetail != "" && startErr.Meta.CLIDetail != tt.wantCLIDetail {
+				t.Fatalf("expected cli detail %q, got %#v", tt.wantCLIDetail, startErr)
+			}
+			if tt.wantParameter == "" {
+				if startErr.Source != nil {
+					t.Fatalf("expected no source parameter, got %#v", startErr)
+				}
+			} else {
+				if startErr.Source == nil || startErr.Source.Parameter != tt.wantParameter {
+					t.Fatalf("expected source parameter %q, got %#v", tt.wantParameter, startErr)
+				}
 			}
 		})
 	}
@@ -435,6 +528,18 @@ func runBinary(args []string, stdin *string) ([]byte, error) {
 		cmd.Stdin = strings.NewReader(*stdin)
 	}
 	return cmd.CombinedOutput()
+}
+
+func resetDesktopSessionState(t *testing.T) {
+	t.Helper()
+
+	sessionsDir := filepath.Join(tmpDir, "local", "state", "flight", "desktop", "sessions")
+	if err := os.RemoveAll(sessionsDir); err != nil {
+		t.Fatalf("failed to remove desktop session state: %v", err)
+	}
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("failed to create desktop session state dir: %v", err)
+	}
 }
 
 func assertExitCode(t *testing.T, expectedExitCode int, output []byte, err error) {

--- a/flight-desktop/main.go
+++ b/flight-desktop/main.go
@@ -125,8 +125,10 @@ func main() {
 
 	if err := cmd.Run(context.Background(), os.Args); err != nil {
 		// A bunch of checks to avoid reporting the usage errors twice.
+		_, isSVE := errors.AsType[startValidationError](err)
 		errStr := err.Error()
-		if (strings.Contains(errStr, "invalid value") && strings.Contains(errStr, "for flag")) ||
+		if !isSVE &&
+			(strings.Contains(errStr, "invalid value") && strings.Contains(errStr, "for flag")) ||
 			(strings.Contains(errStr, "flag provided but not defined")) ||
 			(strings.Contains(errStr, "flag needs an argument")) {
 			// We've already reported the usage error.  No need to do so a
@@ -134,8 +136,8 @@ func main() {
 			os.Exit(1)
 		}
 
-		if strings.Contains(errStr, "cannot be set along with") {
-			log.Printf("\nIncorrect Usage: %s", err)
+		if strings.Contains(errStr, "cannot be set along with") || isSVE {
+			log.Printf("Incorrect Usage: %s", err)
 			os.Exit(1)
 		}
 
@@ -145,19 +147,6 @@ func main() {
 			log.Printf("%s\n", err)
 			os.Exit(1)
 		}
-	}
-}
-
-func composeBeforeFuncs(fns ...cli.BeforeFunc) cli.BeforeFunc {
-	return func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-		var err error
-		for _, fn := range fns {
-			ctx, err = fn(ctx, cmd)
-			if err != nil {
-				return ctx, err
-			}
-		}
-		return ctx, nil
 	}
 }
 

--- a/flight-desktop/session_kill_test.go
+++ b/flight-desktop/session_kill_test.go
@@ -156,6 +156,9 @@ func createDesktopSessionFixture(t *testing.T, session desktopSessionFixture) {
 	t.Helper()
 
 	sessionDir := filepath.Join(tmpDir, "local", "state", "flight", "desktop", "sessions", session.Name)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(sessionDir)
+	})
 	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
 		t.Fatalf("failed to create session dir: %v", err)
 	}

--- a/flight-desktop/session_start.go
+++ b/flight-desktop/session_start.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -32,20 +35,12 @@ func startSessionCommand() *cli.Command {
 		Description: wordwrap.String("Start a new interactive desktop session and display details about the new session.\n\nAvailable desktop types can be shown using the 'avail' command.", maxTextWidth),
 		Category:    "Sessions",
 		Flags: []cli.Flag{
+			formatFlag,
 			&cli.StringFlag{
 				Name:        "name",
 				Aliases:     []string{"n"},
 				Usage:       "Name the desktop session `NAME` so it can be more easily identified.",
 				DefaultText: "random",
-				Validator: func(name string) error {
-					if nameBlacklist.MatchString(name) {
-						return fmt.Errorf("it can contain only %s and cannot start with a hyphen.", nameWhitelistExplanation)
-					}
-					if len(name) > nameMaxLen {
-						return fmt.Errorf("it must be no more than %d characters", nameMaxLen)
-					}
-					return nil
-				},
 			},
 			&cli.StringFlag{
 				Name:    "geometry",
@@ -57,7 +52,7 @@ func startSessionCommand() *cli.Command {
 		Arguments: []cli.Argument{
 			&cli.StringArg{Name: "type", UsageText: "<type>"},
 		},
-		Before: composeBeforeFuncs(assertArgPresent("type"), assertTypeValid("type", 0)),
+		Before: assertArgPresent("type"),
 		ShellComplete: func(ctx context.Context, cmd *cli.Command) {
 			cli.DefaultCompleteWithFlags(ctx, cmd)
 			switch cmd.NArg() {
@@ -73,63 +68,163 @@ func startSessionCommand() *cli.Command {
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			sessionType := cmd.StringArg("type")
-			name := cmd.String("name")
-			if name == "" {
-				name = newNameGenerator(sessionType).Generate()
+			nameInput := cmd.String("name")
+			geometry := cmd.String("geometry")
+			if cmd.String("format") == "json" {
+				return startSessionJSON(ctx, sessionType, nameInput, geometry)
 			}
-			fmt.Printf("Starting '%s' desktop session '%s':\n\n", sessionType, name)
-
-			depsOK, err := checkDependencies(ctx, sessionType)
-
-			if !depsOK {
-				return err
-			}
-
-			p := createPin("Starting session...")
-			cancel := p.Start(ctx)
-			defer cancel()
-
-			session := Session{
-				Name:        name,
-				State:       New,
-				SessionType: sessionType,
-				Geometry:    cmd.String("geometry"),
-			}
-			err = session.Start(ctx)
-			if err != nil {
-				p.Fail("Starting session failed")
-				return err
-			}
-			p.Stop(fmt.Sprintf("Your %s session is ready!", session.SessionType))
-			fmt.Println()
-			sessionStarted(&session)
-			connectionInfo(&session)
-			managementInfo(&session)
-			return nil
+			return startSessionPretty(ctx, sessionType, nameInput, geometry)
 		},
 	}
 }
 
-func assertTypeValid(argName string, argIndex int) cli.BeforeFunc {
-	return func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-		availableTypes, err := loadAllTypes()
-		typeNames := make([]string, 0, len(availableTypes))
-		for _, typ := range availableTypes {
-			typeNames = append(typeNames, typ.ID)
-		}
-		if err != nil {
-			return ctx, err
-		}
-		typ := cmd.Args().Get(argIndex)
-		if !slices.Contains(typeNames, typ) {
-			return ctx, fmt.Errorf(
-				"Incorrect Usage: unknown %s '%s'. Valid values are %s.",
-				argName,
-				typ,
+func startSessionPretty(ctx context.Context, sessionType, nameInput, geometry string) error {
+	if err := validateSessionType(sessionType); err != nil {
+		return err
+	}
+	if err := validateSessionName(nameInput); err != nil {
+		return err
+	}
+	if err := validateGeometry(geometry); err != nil {
+		return err
+	}
+	name := nameInput
+	if name == "" {
+		name = newNameGenerator(sessionType).Generate()
+	}
+	fmt.Printf("Starting '%s' desktop session '%s':\n\n", sessionType, name)
+
+	depsOK, err := checkDependencies(ctx, sessionType)
+
+	if !depsOK {
+		return err
+	}
+
+	p := createPin("Starting session...")
+	cancel := p.Start(ctx)
+	defer cancel()
+
+	session := Session{
+		Name:        name,
+		State:       New,
+		SessionType: sessionType,
+		Geometry:    geometry,
+	}
+	err = session.Start(ctx)
+	if err != nil {
+		p.Fail("Starting session failed")
+		return err
+	}
+	p.Stop(fmt.Sprintf("Your %s session is ready!", session.SessionType))
+	fmt.Println()
+	sessionStarted(&session)
+	connectionInfo(&session)
+	managementInfo(&session)
+	return nil
+}
+
+type sessionStartResponse struct {
+	Success     bool   `json:"success"`
+	SessionName string `json:"session_name"`
+	Error       string `json:"error,omitempty"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+type startValidationError struct {
+	message string // Human-readable error message.
+	reason  string // Machine-readable error message.
+}
+
+func (e startValidationError) Error() string {
+	return e.message
+}
+
+func startSessionJSON(ctx context.Context, sessionType, nameInput, geometry string) error {
+	if err := validateSessionType(sessionType); err != nil {
+		return writeStartFailure(nameInput, err.Error(), startFailureReason(err, "invalid_type"))
+	}
+	if err := validateSessionName(nameInput); err != nil {
+		return writeStartFailure(nameInput, err.Error(), startFailureReason(err, "invalid_name"))
+	}
+	if err := validateGeometry(geometry); err != nil {
+		return writeStartFailure(nameInput, err.Error(), startFailureReason(err, "invalid_geometry"))
+	}
+
+	sessionName := nameInput
+	if sessionName == "" {
+		sessionName = newNameGenerator(sessionType).Generate()
+	}
+
+	depsOK, err := checkDependenciesQuiet(sessionType)
+	if err != nil {
+		return writeStartFailure(sessionName, err.Error(), "start_failed")
+	}
+	if !depsOK {
+		return writeStartFailure(sessionName, fmt.Sprintf("Missing required dependencies for %s desktop type.", sessionType), "dependencies_failed")
+	}
+
+	session := Session{
+		Name:        sessionName,
+		State:       New,
+		SessionType: sessionType,
+		Geometry:    geometry,
+	}
+	if err := session.Start(ctx); err != nil {
+		return writeStartFailure(sessionName, startFailureMessage(sessionName, err), startFailureReason(err, "start_failed"))
+	}
+	return writeStartSuccess(sessionName)
+}
+
+func validateSessionType(sessionType string) error {
+	availableTypes, err := loadAllTypes()
+	if err != nil {
+		return err
+	}
+	typeNames := make([]string, 0, len(availableTypes))
+	for _, typ := range availableTypes {
+		typeNames = append(typeNames, typ.ID)
+	}
+	if !slices.Contains(typeNames, sessionType) {
+		return startValidationError{
+			message: fmt.Sprintf(
+				"Incorrect Usage: unknown type '%s'. Valid values are %s.",
+				sessionType,
 				strings.Join(typeNames, ", "),
-			)
+			),
+			reason: "invalid_type",
 		}
-		return ctx, nil
+	}
+	return nil
+}
+
+func validateSessionName(name string) error {
+	if name == "" {
+		return nil
+	}
+	if nameBlacklist.MatchString(name) {
+		return startValidationError{
+			message: fmt.Sprintf("invalid value %q for flag -name: it can contain only %s and cannot start with a hyphen.", name, nameWhitelistExplanation),
+			reason:  "invalid_name",
+		}
+	}
+	if len(name) > nameMaxLen {
+		return startValidationError{
+			message: fmt.Sprintf("invalid value %q for flag -name: it must be no more than %d characters", name, nameMaxLen),
+			reason:  "invalid_name",
+		}
+	}
+	return nil
+}
+
+var geometryPattern = regexp.MustCompile(`^[1-9]\d*x[1-9]\d*$`)
+
+func validateGeometry(geometry string) error {
+	if geometryPattern.MatchString(geometry) {
+		return nil
+	}
+	return startValidationError{
+		message: fmt.Sprintf("invalid value %q for flag -geometry: it must be in WIDTHxHEIGHT format with positive integers", geometry),
+		reason:  "invalid_geometry",
 	}
 }
 
@@ -171,6 +266,86 @@ func checkDependencies(ctx context.Context, sessionType string) (bool, error) {
 	p.Stop("Dependencies OK")
 
 	return true, err
+}
+
+func checkDependenciesQuiet(sessionType string) (bool, error) {
+	_, globalDepsOK := runDoctor(requiredDependencies(config.Dependencies))
+	if !globalDepsOK {
+		return false, nil
+	}
+
+	sessionTypeDef, err := loadType(sessionType)
+	if err != nil {
+		return false, err
+	}
+	if err := sessionTypeDef.loadDependencies(); err != nil {
+		return false, err
+	}
+
+	_, typeDepsOK := runDoctor(requiredDependencies(sessionTypeDef.dependencies))
+	if !typeDepsOK {
+		return false, nil
+	}
+	return true, nil
+}
+
+func startFailureMessage(sessionName string, err error) string {
+	var validationErr startValidationError
+	switch {
+	case errors.As(err, &validationErr):
+		return err.Error()
+	case strings.Contains(err.Error(), "Session name"):
+		return err.Error()
+	case strings.Contains(err.Error(), "geometry") && strings.Contains(err.Error(), "invalid"):
+		return err.Error()
+	default:
+		return fmt.Sprintf("Starting desktop session '%s' failed.", sessionName)
+	}
+}
+
+func startFailureReason(err error, fallback string) string {
+	var validationErr startValidationError
+	switch {
+	case errors.As(err, &validationErr):
+		return validationErr.reason
+	case strings.Contains(err.Error(), "Session name"):
+		return "invalid_name"
+	case strings.Contains(err.Error(), "geometry") && strings.Contains(err.Error(), "invalid"):
+		return "invalid_geometry"
+	default:
+		return fallback
+	}
+}
+
+func writeStartSuccess(sessionName string) error {
+	return writeStartResponse(sessionStartResponse{
+		Success:     true,
+		SessionName: sessionName,
+	}, 0)
+}
+
+func writeStartFailure(sessionName, message, reason string) error {
+	return writeStartResponse(sessionStartResponse{
+		Success:     false,
+		SessionName: sessionName,
+		Error:       message,
+		Reason:      reason,
+	}, 1)
+}
+
+func writeStartResponse(response sessionStartResponse, exitCode int) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(response); err != nil {
+		return err
+	}
+	if exitCode == 0 {
+		return nil
+	}
+	return SilentExitError{
+		ExitCode:  exitCode,
+		exitError: errors.New("session start failed"),
+	}
 }
 
 func createPin(text string) *pin.Pin {

--- a/flight-desktop/session_start.go
+++ b/flight-desktop/session_start.go
@@ -126,13 +126,34 @@ func startSessionPretty(ctx context.Context, sessionType, nameInput, geometry st
 type sessionStartResponse struct {
 	Success     bool   `json:"success"`
 	SessionName string `json:"session_name"`
-	Error       string `json:"error,omitempty"`
-	Reason      string `json:"reason,omitempty"`
+}
+
+type sessionStartErrorDocument struct {
+	Errors []sessionStartError `json:"errors"`
+}
+
+type sessionStartError struct {
+	Code   string                   `json:"code"`
+	Title  string                   `json:"title"`
+	Detail string                   `json:"detail"`
+	Source *sessionStartErrorSource `json:"source,omitempty"`
+	Meta   sessionStartErrorMeta    `json:"meta"`
+}
+
+type sessionStartErrorSource struct {
+	Parameter string `json:"parameter"`
+}
+
+type sessionStartErrorMeta struct {
+	CLIDetail string `json:"cli_detail"`
 }
 
 type startValidationError struct {
 	message string // Human-readable error message.
 	reason  string // Machine-readable error message.
+	title   string
+	detail  string
+	source  string
 }
 
 func (e startValidationError) Error() string {
@@ -141,13 +162,13 @@ func (e startValidationError) Error() string {
 
 func startSessionJSON(ctx context.Context, sessionType, nameInput, geometry string) error {
 	if err := validateSessionType(sessionType); err != nil {
-		return writeStartFailure(nameInput, err.Error(), startFailureReason(err, "invalid_type"))
+		return writeStartFailure(startFailureError(err, nameInput))
 	}
 	if err := validateSessionName(nameInput); err != nil {
-		return writeStartFailure(nameInput, err.Error(), startFailureReason(err, "invalid_name"))
+		return writeStartFailure(startFailureError(err, nameInput))
 	}
 	if err := validateGeometry(geometry); err != nil {
-		return writeStartFailure(nameInput, err.Error(), startFailureReason(err, "invalid_geometry"))
+		return writeStartFailure(startFailureError(err, nameInput))
 	}
 
 	sessionName := nameInput
@@ -157,10 +178,17 @@ func startSessionJSON(ctx context.Context, sessionType, nameInput, geometry stri
 
 	depsOK, err := checkDependenciesQuiet(sessionType)
 	if err != nil {
-		return writeStartFailure(sessionName, err.Error(), "start_failed")
+		return writeStartFailure(startFailureError(err, nameInput))
 	}
 	if !depsOK {
-		return writeStartFailure(sessionName, fmt.Sprintf("Missing required dependencies for %s desktop type.", sessionType), "dependencies_failed")
+		return writeStartFailure(sessionStartError{
+			Code:   "dependencies_failed",
+			Title:  "Desktop dependencies unavailable",
+			Detail: fmt.Sprintf("Missing required dependencies for %s desktop type.", sessionType),
+			Meta: sessionStartErrorMeta{
+				CLIDetail: fmt.Sprintf("Missing required dependencies for %s desktop type.", sessionType),
+			},
+		})
 	}
 
 	session := Session{
@@ -170,7 +198,7 @@ func startSessionJSON(ctx context.Context, sessionType, nameInput, geometry stri
 		Geometry:    geometry,
 	}
 	if err := session.Start(ctx); err != nil {
-		return writeStartFailure(sessionName, startFailureMessage(sessionName, err), startFailureReason(err, "start_failed"))
+		return writeStartFailure(startFailureError(err, nameInput))
 	}
 	return writeStartSuccess(sessionName)
 }
@@ -187,11 +215,18 @@ func validateSessionType(sessionType string) error {
 	if !slices.Contains(typeNames, sessionType) {
 		return startValidationError{
 			message: fmt.Sprintf(
-				"Incorrect Usage: unknown type '%s'. Valid values are %s.",
+				"unknown type '%s'. Valid values are %s.",
 				sessionType,
 				strings.Join(typeNames, ", "),
 			),
 			reason: "invalid_type",
+			title:  "Invalid desktop type",
+			detail: fmt.Sprintf(
+				"Unknown desktop type '%s'. Valid values are %s.",
+				sessionType,
+				strings.Join(typeNames, ", "),
+			),
+			source: "type",
 		}
 	}
 	return nil
@@ -205,12 +240,18 @@ func validateSessionName(name string) error {
 		return startValidationError{
 			message: fmt.Sprintf("invalid value %q for flag -name: it can contain only %s and cannot start with a hyphen.", name, nameWhitelistExplanation),
 			reason:  "invalid_name",
+			title:   "Invalid session name",
+			detail:  fmt.Sprintf("Session name can contain only %s and cannot start with a hyphen.", nameWhitelistExplanation),
+			source:  "name",
 		}
 	}
 	if len(name) > nameMaxLen {
 		return startValidationError{
 			message: fmt.Sprintf("invalid value %q for flag -name: it must be no more than %d characters", name, nameMaxLen),
 			reason:  "invalid_name",
+			title:   "Invalid session name",
+			detail:  fmt.Sprintf("Session name must be no more than %d characters.", nameMaxLen),
+			source:  "name",
 		}
 	}
 	return nil
@@ -225,6 +266,9 @@ func validateGeometry(geometry string) error {
 	return startValidationError{
 		message: fmt.Sprintf("invalid value %q for flag -geometry: it must be in WIDTHxHEIGHT format with positive integers", geometry),
 		reason:  "invalid_geometry",
+		title:   "Invalid desktop geometry",
+		detail:  "Desktop geometry must be in WIDTHxHEIGHT format with positive integers.",
+		source:  "geometry",
 	}
 }
 
@@ -289,7 +333,7 @@ func checkDependenciesQuiet(sessionType string) (bool, error) {
 	return true, nil
 }
 
-func startFailureMessage(sessionName string, err error) string {
+func startFailureMessage(nameInput string, err error) string {
 	var validationErr startValidationError
 	switch {
 	case errors.As(err, &validationErr):
@@ -298,8 +342,10 @@ func startFailureMessage(sessionName string, err error) string {
 		return err.Error()
 	case strings.Contains(err.Error(), "geometry") && strings.Contains(err.Error(), "invalid"):
 		return err.Error()
+	case nameInput == "":
+		return "Starting desktop session failed."
 	default:
-		return fmt.Sprintf("Starting desktop session '%s' failed.", sessionName)
+		return fmt.Sprintf("Starting desktop session '%s' failed.", nameInput)
 	}
 }
 
@@ -317,6 +363,39 @@ func startFailureReason(err error, fallback string) string {
 	}
 }
 
+func startFailureError(err error, nameInput string) sessionStartError {
+	if validationErr, ok := errors.AsType[startValidationError](err); ok {
+		startErr := sessionStartError{
+			Code:   validationErr.reason,
+			Title:  validationErr.title,
+			Detail: validationErr.detail,
+			Meta: sessionStartErrorMeta{
+				CLIDetail: validationErr.message,
+			},
+		}
+		if validationErr.source != "" {
+			startErr.Source = &sessionStartErrorSource{Parameter: validationErr.source}
+		}
+		return startErr
+	}
+
+	fallbackReason := "start_failed"
+	reason := startFailureReason(err, fallbackReason)
+	detail := startFailureMessage(nameInput, err)
+	title := "Desktop session failed to start"
+	if reason == "dependencies_failed" {
+		title = "Desktop dependencies unavailable"
+	}
+	return sessionStartError{
+		Code:   reason,
+		Title:  title,
+		Detail: detail,
+		Meta: sessionStartErrorMeta{
+			CLIDetail: err.Error(),
+		},
+	}
+}
+
 func writeStartSuccess(sessionName string) error {
 	return writeStartResponse(sessionStartResponse{
 		Success:     true,
@@ -324,16 +403,13 @@ func writeStartSuccess(sessionName string) error {
 	}, 0)
 }
 
-func writeStartFailure(sessionName, message, reason string) error {
-	return writeStartResponse(sessionStartResponse{
-		Success:     false,
-		SessionName: sessionName,
-		Error:       message,
-		Reason:      reason,
+func writeStartFailure(startErr sessionStartError) error {
+	return writeStartResponse(sessionStartErrorDocument{
+		Errors: []sessionStartError{startErr},
 	}, 1)
 }
 
-func writeStartResponse(response sessionStartResponse, exitCode int) error {
+func writeStartResponse(response any, exitCode int) error {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(response); err != nil {

--- a/flight-desktop/testdata/golden/avail-help.golden
+++ b/flight-desktop/testdata/golden/avail-help.golden
@@ -11,7 +11,8 @@ DESCRIPTION:
    Display a list of available desktop types.
 
 OPTIONS:
-   --help, -h  show help
+   --format FORMAT  use specified FORMAT for the output (pretty, json). (default: "pretty")
+   --help, -h       show help
 
 GLOBAL OPTIONS:
    --log-level LEVEL  set the log LEVEL (debug, info, warn, error, fatal). Default: warn

--- a/flight-desktop/testdata/golden/start-help.golden
+++ b/flight-desktop/testdata/golden/start-help.golden
@@ -14,6 +14,7 @@ DESCRIPTION:
    Available desktop types can be shown using the 'avail' command.
 
 OPTIONS:
+   --format FORMAT                           use specified FORMAT for the output (pretty, json). (default: "pretty")
    --name NAME, -n NAME                      Name the desktop session NAME so it can be more easily identified. (default: random)
    --geometry WIDTHxHEIGHT, -g WIDTHxHEIGHT  Set the desktop geometry to WIDTHxHEIGHT. (default: "1024x768")
    --help, -h                                show help

--- a/flight-desktop/type.go
+++ b/flight-desktop/type.go
@@ -56,9 +56,9 @@ func loadType(id string) (*Type, error) {
 }
 
 type Type struct {
-	ID           string `yaml:"id"`
-	Summary      string `yaml:"summary"`
-	URL          string `yaml:"url"`
+	ID           string `json:"id" yaml:"id"`
+	Summary      string `json:"summary" yaml:"summary"`
+	URL          string `json:"url" yaml:"url"`
 	dependencies []dependency
 }
 

--- a/flight-desktop/type_avail.go
+++ b/flight-desktop/type_avail.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"slices"
 
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/table"
@@ -18,22 +21,31 @@ func typeAvailCommand() *cli.Command {
 		Usage:       "Show available desktop types",
 		Description: wordwrap.String("Display a list of available desktop types.", maxTextWidth),
 		Category:    "Desktop types",
+		Flags:       []cli.Flag{formatFlag},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			types, err := loadAllTypes()
 			if err != nil {
 				return err
 			}
+			slices.SortFunc(types, func(a, b *Type) int {
+				return compareStrings(a.ID, b.ID)
+			})
+			if cmd.String("format") == "json" {
+				return writeTypesJSON(types)
+			}
 			if len(types) == 0 {
 				fmt.Println("No desktop types found.")
 				return nil
 			}
-			err = typesTable(types)
-			if err != nil {
-				return err
-			}
-			return nil
+			return typesTable(types)
 		},
 	}
+}
+
+func writeTypesJSON(types []*Type) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(types)
 }
 
 func typesTable(types []*Type) error {
@@ -100,4 +112,15 @@ type UnknownType struct {
 
 func (ut UnknownType) Error() string {
 	return fmt.Sprintf("Unknown desktop type: %s", ut.Type)
+}
+
+func compareStrings(a, b string) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
 }

--- a/flight-web-suite/desktop/build_command.go
+++ b/flight-web-suite/desktop/build_command.go
@@ -1,0 +1,91 @@
+// Package desktop provides functions and types for running the
+// `flight-desktop` CLI and parsing its output.
+package desktop
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/concertim/flight-user-suite/flight/configenv"
+)
+
+func desktopToolPath(env configenv.Env) string {
+	return filepath.Join(env.FlightRoot, "usr", "lib", "flight-core", "flight-desktop")
+}
+
+func buildDesktopCommand(ctx context.Context, env configenv.Env, username string, args ...string) (*exec.Cmd, error) {
+	userInfo, err := user.Lookup(username)
+	if err != nil {
+		return nil, fmt.Errorf("looking up user %q: %w", username, err)
+	}
+
+	uid, err := strconv.Atoi(userInfo.Uid)
+	if err != nil {
+		return nil, fmt.Errorf("parsing uid for user %q: %w", userInfo.Username, err)
+	}
+	gid, err := strconv.Atoi(userInfo.Gid)
+	if err != nil {
+		return nil, fmt.Errorf("parsing gid for user %q: %w", userInfo.Username, err)
+	}
+
+	groupIDs, err := userInfo.GroupIds()
+	if err != nil {
+		return nil, fmt.Errorf("looking up groups for user %q: %w", userInfo.Username, err)
+	}
+	groups := make([]uint32, 0, len(groupIDs))
+	for _, groupID := range groupIDs {
+		parsed, err := strconv.Atoi(groupID)
+		if err != nil {
+			return nil, fmt.Errorf("parsing group id %q for user %q: %w", groupID, userInfo.Username, err)
+		}
+		groups = append(groups, uint32(parsed))
+	}
+
+	cmd := exec.CommandContext(ctx, desktopToolPath(env), args...)
+	cmd.Dir = userInfo.HomeDir
+	cmd.Env = commandEnv(userInfo)
+	if os.Geteuid() == 0 {
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Credential: &syscall.Credential{
+				Uid:    uint32(uid),
+				Gid:    uint32(gid),
+				Groups: groups,
+			},
+		}
+	} else if os.Geteuid() != uid {
+		return nil, fmt.Errorf("cannot run desktop listing as %q without root privileges", userInfo.Username)
+	}
+	return cmd, nil
+}
+
+func commandEnv(userInfo *user.User) []string {
+	env := slices.Clone(os.Environ())
+	env = slices.DeleteFunc(env, func(envar string) bool {
+		parts := strings.SplitN(envar, "=", 2)
+		name := parts[0]
+		return strings.HasPrefix(name, "XDG_")
+	})
+	env = upsertEnv(env, "HOME", userInfo.HomeDir)
+	env = upsertEnv(env, "LOGNAME", userInfo.Username)
+	env = upsertEnv(env, "USER", userInfo.Username)
+	return env
+}
+
+func upsertEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	for i, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			env[i] = prefix + value
+			return env
+		}
+	}
+	return append(env, prefix+value)
+}

--- a/flight-web-suite/desktop/build_command.go
+++ b/flight-web-suite/desktop/build_command.go
@@ -61,7 +61,7 @@ func buildDesktopCommand(ctx context.Context, env configenv.Env, username string
 			},
 		}
 	} else if os.Geteuid() != uid {
-		return nil, fmt.Errorf("cannot run desktop listing as %q without root privileges", userInfo.Username)
+		return nil, fmt.Errorf("cannot run desktop command as %q without root privileges", userInfo.Username)
 	}
 	return cmd, nil
 }

--- a/flight-web-suite/desktop/kill.go
+++ b/flight-web-suite/desktop/kill.go
@@ -1,0 +1,43 @@
+package desktop
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/concertim/flight-user-suite/flight/configenv"
+)
+
+type terminationResponse struct {
+	Success     bool   `json:"success"`
+	SessionName string `json:"session_name"`
+	Error       string `json:"error"`
+	Reason      string `json:"reason"`
+}
+
+func KillCommand(ctx context.Context, env configenv.Env, username, sessionName string) (terminationResponse, error) {
+	cmd, err := buildDesktopCommand(ctx, env, username, "kill", "--format", "json", "--", sessionName)
+	if err != nil {
+		return terminationResponse{}, err
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	var response terminationResponse
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &response); decodeErr == nil {
+		return response, nil
+	}
+
+	if runErr != nil {
+		if stderr.Len() != 0 {
+			return terminationResponse{}, fmt.Errorf("terminating desktop session: %s", stderr.String())
+		}
+		return terminationResponse{}, fmt.Errorf("terminating desktop session: %w", runErr)
+	}
+	return terminationResponse{}, fmt.Errorf("decoding desktop termination response: %s", stdout.String())
+}

--- a/flight-web-suite/desktop/launch.go
+++ b/flight-web-suite/desktop/launch.go
@@ -1,0 +1,118 @@
+package desktop
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/concertim/flight-user-suite/flight/configenv"
+)
+
+type Type struct {
+	ID      string `json:"id"`
+	Summary string `json:"summary"`
+	URL     string `json:"url"`
+}
+
+type StartInput struct {
+	DesktopType string
+	Name        string
+	Geometry    string
+}
+
+type StartResponse struct {
+	Success     bool
+	SessionName string
+	Error       startError
+}
+
+type startError struct {
+	Code   string            `json:"code"`
+	Title  string            `json:"title"`
+	Detail string            `json:"detail"`
+	Source *startErrorSource `json:"source,omitempty"`
+}
+
+type startErrorSource struct {
+	Parameter string `json:"parameter"`
+}
+
+type startSuccessDocument struct {
+	Success     *bool  `json:"success"`
+	SessionName string `json:"session_name"`
+}
+
+type startErrorDocument struct {
+	Errors []startError `json:"errors"`
+}
+
+func AvailCommand(ctx context.Context, env configenv.Env, username string) ([]*Type, error) {
+	cmd, err := buildDesktopCommand(ctx, env, username, "avail", "--format", "json")
+	if err != nil {
+		return nil, err
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if stderr.Len() != 0 {
+			return nil, fmt.Errorf("listing desktop types: %s", stderr.String())
+		}
+		return nil, fmt.Errorf("listing desktop types: %w", err)
+	}
+
+	var desktopTypes []*Type
+	if err := json.Unmarshal(stdout.Bytes(), &desktopTypes); err != nil {
+		return nil, fmt.Errorf("decoding desktop types: %w", err)
+	}
+	slices.SortFunc(desktopTypes, func(a, b *Type) int {
+		return strings.Compare(a.ID, b.ID)
+	})
+	return desktopTypes, nil
+}
+
+func StartCommand(ctx context.Context, env configenv.Env, username string, input StartInput) (StartResponse, error) {
+	args := []string{"start", input.DesktopType, "--format", "json", "--geometry", input.Geometry}
+	if input.Name != "" {
+		args = append(args, "--name", input.Name)
+	}
+
+	cmd, err := buildDesktopCommand(ctx, env, username, args...)
+	if err != nil {
+		return StartResponse{}, err
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	var successDoc startSuccessDocument
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &successDoc); decodeErr == nil && successDoc.Success != nil {
+		return StartResponse{
+			Success:     *successDoc.Success,
+			SessionName: successDoc.SessionName,
+		}, nil
+	}
+
+	var errorDoc startErrorDocument
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &errorDoc); decodeErr == nil && len(errorDoc.Errors) > 0 {
+		return StartResponse{
+			Success: false,
+			Error:   errorDoc.Errors[0],
+		}, nil
+	}
+	if runErr != nil {
+		if stderr.Len() != 0 {
+			return StartResponse{}, fmt.Errorf("starting desktop session: %s", stderr.String())
+		}
+		return StartResponse{}, fmt.Errorf("starting desktop session: %w", runErr)
+	}
+	return StartResponse{}, fmt.Errorf("decoding desktop start response: %s", stdout.String())
+}

--- a/flight-web-suite/desktop/list.go
+++ b/flight-web-suite/desktop/list.go
@@ -1,0 +1,43 @@
+package desktop
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/concertim/flight-user-suite/flight/configenv"
+)
+
+type Session struct {
+	Name        string    `json:"name"`
+	DesktopType string    `json:"desktop_type"`
+	State       string    `json:"state"`
+	Host        string    `json:"host"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+func ListCommand(ctx context.Context, env configenv.Env, username string) ([]*Session, error) {
+	cmd, err := buildDesktopCommand(ctx, env, username, "list", "--format", "json")
+	if err != nil {
+		return nil, err
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if stderr.Len() != 0 {
+			return nil, fmt.Errorf("listing desktop sessions: %s", stderr.String())
+		}
+		return nil, fmt.Errorf("listing desktop sessions: %w", err)
+	}
+
+	var sessions []*Session
+	if err := json.Unmarshal(stdout.Bytes(), &sessions); err != nil {
+		return nil, fmt.Errorf("decoding desktop sessions: %w", err)
+	}
+	return sessions, nil
+}

--- a/flight-web-suite/desktop_launch.go
+++ b/flight-web-suite/desktop_launch.go
@@ -1,60 +1,18 @@
 package main
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"slices"
-	"strings"
 
+	"github.com/concertim/flight-user-suite/flight-web-suite/desktop"
 	"github.com/concertim/flight-user-suite/flight/toolset"
 	"github.com/labstack/echo/v5"
 )
-
-type desktopType struct {
-	ID      string `json:"id"`
-	Summary string `json:"summary"`
-	URL     string `json:"url"`
-}
 
 type desktopGeometryOption struct {
 	Value   string
 	Label   string
 	Default bool
-}
-
-type desktopStartInput struct {
-	DesktopType string
-	Name        string
-	Geometry    string
-}
-
-type desktopStartResponse struct {
-	Success     bool
-	SessionName string
-	Error       desktopStartError
-}
-
-type desktopStartSuccessDocument struct {
-	Success     *bool  `json:"success"`
-	SessionName string `json:"session_name"`
-}
-
-type desktopStartErrorDocument struct {
-	Errors []desktopStartError `json:"errors"`
-}
-
-type desktopStartError struct {
-	Code   string                   `json:"code"`
-	Title  string                   `json:"title"`
-	Detail string                   `json:"detail"`
-	Source *desktopStartErrorSource `json:"source,omitempty"`
-}
-
-type desktopStartErrorSource struct {
-	Parameter string `json:"parameter"`
 }
 
 type desktopLaunchFieldErrors struct {
@@ -84,7 +42,7 @@ func newDesktopSessionHandler(c *echo.Context) error {
 		return err
 	}
 
-	desktopTypes, err := desktopAvailCommand(c.Request().Context(), CurrentUserName(c))
+	desktopTypes, err := desktop.AvailCommand(c.Request().Context(), env, CurrentUserName(c))
 	if err != nil {
 		return err
 	}
@@ -110,14 +68,14 @@ func createDesktopSessionHandler(c *echo.Context) error {
 		Geometry:    c.FormValue("geometry"),
 	}
 
-	desktopTypes, err := desktopAvailCommand(c.Request().Context(), CurrentUserName(c))
+	desktopTypes, err := desktop.AvailCommand(c.Request().Context(), env, CurrentUserName(c))
 	if err != nil {
 		return err
 	}
 
 	validateDesktopLaunchForm(desktopTypes, &form)
 	if form.Errors == (desktopLaunchFieldErrors{}) {
-		response, err := desktopStartCommand(c.Request().Context(), CurrentUserName(c), desktopStartInput{
+		response, err := desktop.StartCommand(c.Request().Context(), env, CurrentUserName(c), desktop.StartInput{
 			DesktopType: form.DesktopType,
 			Name:        form.Name,
 			Geometry:    form.Geometry,
@@ -158,75 +116,7 @@ func requireDesktopToolEnabled() error {
 	return nil
 }
 
-func desktopAvailCommand(ctx context.Context, username string) ([]desktopType, error) {
-	cmd, err := buildDesktopCommand(ctx, username, "avail", "--format", "json")
-	if err != nil {
-		return nil, err
-	}
-
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		if stderr.Len() != 0 {
-			return nil, fmt.Errorf("listing desktop types: %s", stderr.String())
-		}
-		return nil, fmt.Errorf("listing desktop types: %w", err)
-	}
-
-	var desktopTypes []desktopType
-	if err := json.Unmarshal(stdout.Bytes(), &desktopTypes); err != nil {
-		return nil, fmt.Errorf("decoding desktop types: %w", err)
-	}
-	slices.SortFunc(desktopTypes, func(a, b desktopType) int {
-		return strings.Compare(a.ID, b.ID)
-	})
-	return desktopTypes, nil
-}
-
-func desktopStartCommand(ctx context.Context, username string, input desktopStartInput) (desktopStartResponse, error) {
-	args := []string{"start", input.DesktopType, "--format", "json", "--geometry", input.Geometry}
-	if input.Name != "" {
-		args = append(args, "--name", input.Name)
-	}
-
-	cmd, err := buildDesktopCommand(ctx, username, args...)
-	if err != nil {
-		return desktopStartResponse{}, err
-	}
-
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	runErr := cmd.Run()
-
-	var successDoc desktopStartSuccessDocument
-	if decodeErr := json.Unmarshal(stdout.Bytes(), &successDoc); decodeErr == nil && successDoc.Success != nil {
-		return desktopStartResponse{
-			Success:     *successDoc.Success,
-			SessionName: successDoc.SessionName,
-		}, nil
-	}
-
-	var errorDoc desktopStartErrorDocument
-	if decodeErr := json.Unmarshal(stdout.Bytes(), &errorDoc); decodeErr == nil && len(errorDoc.Errors) > 0 {
-		return desktopStartResponse{
-			Success: false,
-			Error:   errorDoc.Errors[0],
-		}, nil
-	}
-	if runErr != nil {
-		if stderr.Len() != 0 {
-			return desktopStartResponse{}, fmt.Errorf("starting desktop session: %s", stderr.String())
-		}
-		return desktopStartResponse{}, fmt.Errorf("starting desktop session: %w", runErr)
-	}
-	return desktopStartResponse{}, fmt.Errorf("decoding desktop start response: %s", stdout.String())
-}
-
-func validateDesktopLaunchForm(desktopTypes []desktopType, form *desktopLaunchFormData) {
+func validateDesktopLaunchForm(desktopTypes []*desktop.Type, form *desktopLaunchFormData) {
 	if !hasDesktopType(desktopTypes, form.DesktopType) {
 		form.Errors.DesktopType = "Select an available desktop type."
 	}
@@ -235,7 +125,7 @@ func validateDesktopLaunchForm(desktopTypes []desktopType, form *desktopLaunchFo
 	}
 }
 
-func applyDesktopStartErrors(form *desktopLaunchFormData, response desktopStartResponse) {
+func applyDesktopStartErrors(form *desktopLaunchFormData, response desktop.StartResponse) {
 	form.Alert = "Failed to launch desktop session."
 	if response.Error.Code == "dependencies_failed" {
 		form.Alert = response.Error.Detail
@@ -250,7 +140,7 @@ func applyDesktopStartErrors(form *desktopLaunchFormData, response desktopStartR
 	}
 }
 
-func renderDesktopLaunchPage(c *echo.Context, status int, desktopTypes []desktopType, form desktopLaunchFormData) error {
+func renderDesktopLaunchPage(c *echo.Context, status int, desktopTypes []*desktop.Type, form desktopLaunchFormData) error {
 	if form.DesktopType == "" {
 		form.DesktopType = defaultDesktopType(desktopTypes)
 	}
@@ -266,7 +156,7 @@ func renderDesktopLaunchPage(c *echo.Context, status int, desktopTypes []desktop
 	return c.Render(status, "desktop/new", AddCommonData(c, data))
 }
 
-func defaultDesktopType(desktopTypes []desktopType) string {
+func defaultDesktopType(desktopTypes []*desktop.Type) string {
 	if len(desktopTypes) == 0 {
 		return ""
 	}
@@ -282,7 +172,7 @@ func defaultDesktopGeometry() string {
 	return ""
 }
 
-func hasDesktopType(desktopTypes []desktopType, id string) bool {
+func hasDesktopType(desktopTypes []*desktop.Type, id string) bool {
 	for _, desktopType := range desktopTypes {
 		if desktopType.ID == id {
 			return true

--- a/flight-web-suite/desktop_launch.go
+++ b/flight-web-suite/desktop_launch.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/concertim/flight-user-suite/flight/toolset"
+	"github.com/labstack/echo/v5"
+)
+
+type desktopType struct {
+	ID      string `json:"id"`
+	Summary string `json:"summary"`
+	URL     string `json:"url"`
+}
+
+type desktopGeometryOption struct {
+	Value   string
+	Label   string
+	Default bool
+}
+
+type desktopStartInput struct {
+	DesktopType string
+	Name        string
+	Geometry    string
+}
+
+type desktopStartResponse struct {
+	Success     bool   `json:"success"`
+	SessionName string `json:"session_name"`
+	Error       string `json:"error"`
+	Reason      string `json:"reason"`
+}
+
+type desktopLaunchFieldErrors struct {
+	DesktopType string
+	Name        string
+	Geometry    string
+}
+
+type desktopLaunchFormData struct {
+	DesktopType string
+	Name        string
+	Geometry    string
+	Errors      desktopLaunchFieldErrors
+	FormError   string
+}
+
+var desktopGeometryOptions = []desktopGeometryOption{
+	{Value: "1024x768", Label: "1024 x 768 (default)", Default: true},
+	{Value: "1280x1024", Label: "1280 x 1024"},
+}
+
+func newDesktopSessionHandler(c *echo.Context) error {
+	if !IsLoggedIn(c) {
+		return c.Redirect(http.StatusSeeOther, "/sessions")
+	}
+	if err := requireDesktopToolEnabled(); err != nil {
+		return err
+	}
+
+	desktopTypes, err := desktopAvailCommand(c.Request().Context(), CurrentUserName(c))
+	if err != nil {
+		return err
+	}
+
+	form := desktopLaunchFormData{
+		DesktopType: defaultDesktopType(desktopTypes),
+		Geometry:    defaultDesktopGeometry(),
+	}
+	return renderDesktopLaunchPage(c, http.StatusOK, desktopTypes, form)
+}
+
+func createDesktopSessionHandler(c *echo.Context) error {
+	if !IsLoggedIn(c) {
+		return c.Redirect(http.StatusSeeOther, "/sessions")
+	}
+	if err := requireDesktopToolEnabled(); err != nil {
+		return err
+	}
+
+	form := desktopLaunchFormData{
+		DesktopType: c.FormValue("desktop_type"),
+		Name:        c.FormValue("name"),
+		Geometry:    c.FormValue("geometry"),
+	}
+
+	desktopTypes, err := desktopAvailCommand(c.Request().Context(), CurrentUserName(c))
+	if err != nil {
+		return err
+	}
+
+	validateDesktopLaunchForm(desktopTypes, &form)
+	if form.Errors == (desktopLaunchFieldErrors{}) {
+		response, err := desktopStartCommand(c.Request().Context(), CurrentUserName(c), desktopStartInput{
+			DesktopType: form.DesktopType,
+			Name:        form.Name,
+			Geometry:    form.Geometry,
+		})
+		if err != nil {
+			return err
+		}
+		if response.Success {
+			sess, err := GetSession(c)
+			if err != nil {
+				return err
+			}
+			sess.AddFlash(fmt.Sprintf("Desktop session '%s' launched.", response.SessionName), "notice")
+			SaveSession(c, sess)
+			return c.Redirect(http.StatusSeeOther, "/desktop")
+		}
+		applyDesktopStartErrors(&form, response)
+	}
+
+	sess, err := GetSession(c)
+	if err != nil {
+		return err
+	}
+	alertMessage := form.FormError
+	if alertMessage == "" {
+		alertMessage = "Failed to launch desktop session."
+	}
+	sess.AddFlash(alertMessage, "alert")
+	SaveSession(c, sess)
+	return renderDesktopLaunchPage(c, http.StatusUnprocessableEntity, desktopTypes, form)
+}
+
+func requireDesktopToolEnabled() error {
+	tool, err := toolset.GetTool(env.FlightRoot, "desktop")
+	if err != nil || !tool.Enabled {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "Flight Desktop is not enabled")
+	}
+	return nil
+}
+
+func desktopAvailCommand(ctx context.Context, username string) ([]desktopType, error) {
+	cmd, err := buildDesktopCommand(ctx, username, "avail", "--format", "json")
+	if err != nil {
+		return nil, err
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if stderr.Len() != 0 {
+			return nil, fmt.Errorf("listing desktop types: %s", stderr.String())
+		}
+		return nil, fmt.Errorf("listing desktop types: %w", err)
+	}
+
+	var desktopTypes []desktopType
+	if err := json.Unmarshal(stdout.Bytes(), &desktopTypes); err != nil {
+		return nil, fmt.Errorf("decoding desktop types: %w", err)
+	}
+	slices.SortFunc(desktopTypes, func(a, b desktopType) int {
+		return strings.Compare(a.ID, b.ID)
+	})
+	return desktopTypes, nil
+}
+
+func desktopStartCommand(ctx context.Context, username string, input desktopStartInput) (desktopStartResponse, error) {
+	args := []string{"start", input.DesktopType, "--format", "json", "--geometry", input.Geometry}
+	if input.Name != "" {
+		args = append(args, "--name", input.Name)
+	}
+
+	cmd, err := buildDesktopCommand(ctx, username, args...)
+	if err != nil {
+		return desktopStartResponse{}, err
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	var response desktopStartResponse
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &response); decodeErr == nil {
+		return response, nil
+	}
+	if runErr != nil {
+		if stderr.Len() != 0 {
+			return desktopStartResponse{}, fmt.Errorf("starting desktop session: %s", stderr.String())
+		}
+		return desktopStartResponse{}, fmt.Errorf("starting desktop session: %w", runErr)
+	}
+	return desktopStartResponse{}, fmt.Errorf("decoding desktop start response: %s", stdout.String())
+}
+
+func validateDesktopLaunchForm(desktopTypes []desktopType, form *desktopLaunchFormData) {
+	if !hasDesktopType(desktopTypes, form.DesktopType) {
+		form.Errors.DesktopType = "Select an available desktop type."
+	}
+	if !hasDesktopGeometry(form.Geometry) {
+		form.Errors.Geometry = "Select a supported geometry."
+	}
+}
+
+func applyDesktopStartErrors(form *desktopLaunchFormData, response desktopStartResponse) {
+	switch response.Reason {
+	case "invalid_type":
+		form.Errors.DesktopType = response.Error
+	case "invalid_name":
+		form.Errors.Name = response.Error
+	case "invalid_geometry":
+		form.Errors.Geometry = response.Error
+	default:
+		form.FormError = response.Error
+	}
+}
+
+func renderDesktopLaunchPage(c *echo.Context, status int, desktopTypes []desktopType, form desktopLaunchFormData) error {
+	if form.DesktopType == "" {
+		form.DesktopType = defaultDesktopType(desktopTypes)
+	}
+	if form.Geometry == "" {
+		form.Geometry = defaultDesktopGeometry()
+	}
+
+	data := map[string]any{
+		"DesktopTypes":    desktopTypes,
+		"GeometryOptions": desktopGeometryOptions,
+		"Form":            form,
+	}
+	return c.Render(status, "desktop/new", AddCommonData(c, data))
+}
+
+func defaultDesktopType(desktopTypes []desktopType) string {
+	if len(desktopTypes) == 0 {
+		return ""
+	}
+	return desktopTypes[0].ID
+}
+
+func defaultDesktopGeometry() string {
+	for _, option := range desktopGeometryOptions {
+		if option.Default {
+			return option.Value
+		}
+	}
+	return ""
+}
+
+func hasDesktopType(desktopTypes []desktopType, id string) bool {
+	for _, desktopType := range desktopTypes {
+		if desktopType.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDesktopGeometry(geometry string) bool {
+	for _, option := range desktopGeometryOptions {
+		if option.Value == geometry {
+			return true
+		}
+	}
+	return false
+}

--- a/flight-web-suite/desktop_launch.go
+++ b/flight-web-suite/desktop_launch.go
@@ -32,10 +32,29 @@ type desktopStartInput struct {
 }
 
 type desktopStartResponse struct {
-	Success     bool   `json:"success"`
+	Success     bool
+	SessionName string
+	Error       desktopStartError
+}
+
+type desktopStartSuccessDocument struct {
+	Success     *bool  `json:"success"`
 	SessionName string `json:"session_name"`
-	Error       string `json:"error"`
-	Reason      string `json:"reason"`
+}
+
+type desktopStartErrorDocument struct {
+	Errors []desktopStartError `json:"errors"`
+}
+
+type desktopStartError struct {
+	Code   string                   `json:"code"`
+	Title  string                   `json:"title"`
+	Detail string                   `json:"detail"`
+	Source *desktopStartErrorSource `json:"source,omitempty"`
+}
+
+type desktopStartErrorSource struct {
+	Parameter string `json:"parameter"`
 }
 
 type desktopLaunchFieldErrors struct {
@@ -49,7 +68,7 @@ type desktopLaunchFormData struct {
 	Name        string
 	Geometry    string
 	Errors      desktopLaunchFieldErrors
-	FormError   string
+	Alert       string
 }
 
 var desktopGeometryOptions = []desktopGeometryOption{
@@ -122,11 +141,11 @@ func createDesktopSessionHandler(c *echo.Context) error {
 	if err != nil {
 		return err
 	}
-	alertMessage := form.FormError
-	if alertMessage == "" {
-		alertMessage = "Failed to launch desktop session."
+	alert := form.Alert
+	if alert == "" {
+		alert = "Failed to launch desktop session."
 	}
-	sess.AddFlash(alertMessage, "alert")
+	sess.AddFlash(alert, "alert")
 	SaveSession(c, sess)
 	return renderDesktopLaunchPage(c, http.StatusUnprocessableEntity, desktopTypes, form)
 }
@@ -183,9 +202,20 @@ func desktopStartCommand(ctx context.Context, username string, input desktopStar
 	cmd.Stderr = &stderr
 	runErr := cmd.Run()
 
-	var response desktopStartResponse
-	if decodeErr := json.Unmarshal(stdout.Bytes(), &response); decodeErr == nil {
-		return response, nil
+	var successDoc desktopStartSuccessDocument
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &successDoc); decodeErr == nil && successDoc.Success != nil {
+		return desktopStartResponse{
+			Success:     *successDoc.Success,
+			SessionName: successDoc.SessionName,
+		}, nil
+	}
+
+	var errorDoc desktopStartErrorDocument
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &errorDoc); decodeErr == nil && len(errorDoc.Errors) > 0 {
+		return desktopStartResponse{
+			Success: false,
+			Error:   errorDoc.Errors[0],
+		}, nil
 	}
 	if runErr != nil {
 		if stderr.Len() != 0 {
@@ -206,15 +236,17 @@ func validateDesktopLaunchForm(desktopTypes []desktopType, form *desktopLaunchFo
 }
 
 func applyDesktopStartErrors(form *desktopLaunchFormData, response desktopStartResponse) {
-	switch response.Reason {
-	case "invalid_type":
-		form.Errors.DesktopType = response.Error
-	case "invalid_name":
-		form.Errors.Name = response.Error
-	case "invalid_geometry":
-		form.Errors.Geometry = response.Error
-	default:
-		form.FormError = response.Error
+	form.Alert = "Failed to launch desktop session."
+	if response.Error.Code == "dependencies_failed" {
+		form.Alert = response.Error.Detail
+	}
+	switch {
+	case response.Error.Source != nil && response.Error.Source.Parameter == "type":
+		form.Errors.DesktopType = response.Error.Detail
+	case response.Error.Source != nil && response.Error.Source.Parameter == "name":
+		form.Errors.Name = response.Error.Detail
+	case response.Error.Source != nil && response.Error.Source.Parameter == "geometry":
+		form.Errors.Geometry = response.Error.Detail
 	}
 }
 

--- a/flight-web-suite/desktop_launch_functional_test.go
+++ b/flight-web-suite/desktop_launch_functional_test.go
@@ -90,9 +90,9 @@ fi
 	_, body := testutil.RenderPage(t, newApp(), http.MethodGet, "/desktop/new", nil, http.StatusOK, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
 
 	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-back-link"]`, testutil.HasAttr("href", "/desktop"))
-	testutil.AssertSelection(t, body, `[data-testid="desktop-type-heading--gnome"]`, testutil.HasText("gnome"))
-	testutil.AssertSelection(t, body, `[data-testid="desktop-type-summary--gnome"]`, testutil.HasText("GNOME desktop."))
-	testutil.AssertSelection(t, body, `[data-testid="desktop-type-url--gnome"]`, testutil.HasAttr("href", "https://example.invalid/gnome"))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-type-card--gnome"] h3`, testutil.HasText("gnome"))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-type-card--gnome"] h3 + p`, testutil.HasText("GNOME desktop."))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-type-card--gnome"] a`, testutil.HasAttr("href", "https://example.invalid/gnome"))
 	testutil.AssertSelection(t, body, `[data-testid="desktop-type-input--gnome"]`, testutil.HasAttr("checked", ""))
 	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-geometry-option--1024x768"]`, testutil.HasAttr("selected", ""))
 
@@ -255,10 +255,16 @@ exit 0
 fi
 cat <<'JSON'
 {
-  "success": false,
-  "session_name": "custom-session",
-  "error": "Invalid session name.",
-  "reason": "invalid_name"
+  "errors": [
+    {
+      "code": "invalid_name",
+      "title": "Invalid session name",
+      "detail": "Invalid session name.",
+      "source": {
+        "parameter": "name"
+      }
+    }
+  ]
 }
 JSON
 exit 1
@@ -284,6 +290,110 @@ exit 1
 	testutil.AssertSelection(t, body, `[data-testid="desktop-type-input--xterm"]`, testutil.HasAttr("checked", ""))
 	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-geometry-option--1280x1024"]`, testutil.HasAttr("selected", ""))
 	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-name-error"]`, testutil.HasText("Invalid session name."))
+}
+
+func TestCreateDesktopSessionFailureWithoutProvidedNameDoesNotExposeGeneratedName(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+if [ "$1" = "avail" ]; then
+cat <<'JSON'
+[
+  {
+    "id": "xterm",
+    "summary": "Minimal terminal desktop.",
+    "url": "https://example.invalid/xterm"
+  }
+]
+JSON
+exit 0
+fi
+cat <<'JSON'
+{
+  "errors": [
+    {
+      "code": "start_failed",
+      "title": "Desktop session failed to start",
+      "detail": "Starting desktop session failed."
+    }
+  ]
+}
+JSON
+exit 1
+`))
+
+	_, body := testutil.RenderPage(
+		t,
+		newApp(),
+		http.MethodPost,
+		"/desktop",
+		strings.NewReader(url.Values{
+			"desktop_type": {"xterm"},
+			"name":         {""},
+			"geometry":     {"1024x768"},
+		}.Encode()),
+		http.StatusUnprocessableEntity,
+		testutil.WithContentType("application/x-www-form-urlencoded"),
+		testutil.WithSessionCookie(currentUser.Username, config.Session.Secret),
+	)
+
+	testutil.AssertSelection(t, body, `div.flash.alert`, testutil.HasText("Failed to launch desktop session."))
+	if strings.Contains(body, "xterm.secret-name") {
+		t.Fatalf("expected generated session name to be hidden on launch failure, got body:\n%s", body)
+	}
+}
+
+func TestCreateDesktopSessionInvalidNameShowsUserFriendlyMessage(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+if [ "$1" = "avail" ]; then
+cat <<'JSON'
+[
+  {
+    "id": "xterm",
+    "summary": "Minimal terminal desktop.",
+    "url": "https://example.invalid/xterm"
+  }
+]
+JSON
+exit 0
+fi
+cat <<'JSON'
+{
+  "errors": [
+    {
+      "code": "invalid_name",
+      "title": "Invalid session name",
+      "detail": "Session name can contain only letters, numbers, hyphens, underscores and dots and cannot start with a hyphen.",
+      "source": {
+        "parameter": "name"
+      }
+    }
+  ]
+}
+JSON
+exit 1
+`))
+
+	_, body := testutil.RenderPage(
+		t,
+		newApp(),
+		http.MethodPost,
+		"/desktop",
+		strings.NewReader(url.Values{
+			"desktop_type": {"xterm"},
+			"name":         {"--foo"},
+			"geometry":     {"1024x768"},
+		}.Encode()),
+		http.StatusUnprocessableEntity,
+		testutil.WithContentType("application/x-www-form-urlencoded"),
+		testutil.WithSessionCookie(currentUser.Username, config.Session.Secret),
+	)
+
+	want := "Session name can contain only letters, numbers, hyphens, underscores and dots and cannot start with a hyphen."
+	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-name-error"]`, testutil.HasText(want))
+	if strings.Contains(body, "for flag -name") {
+		t.Fatalf("expected user-facing validation message without CLI flag details, got body:\n%s", body)
+	}
 }
 
 func TestCreateDesktopSessionWithInvalidGeometryShowsInlineErrorWithoutInvokingStart(t *testing.T) {

--- a/flight-web-suite/desktop_launch_functional_test.go
+++ b/flight-web-suite/desktop_launch_functional_test.go
@@ -1,0 +1,376 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/concertim/flight-user-suite/flight-web-suite/internal/testutil"
+)
+
+func TestNewDesktopSessionRedirectsForAnonymous(t *testing.T) {
+	resp, _ := testutil.RenderPage(t, newApp(), http.MethodGet, "/desktop/new", nil, http.StatusSeeOther)
+
+	if resp.Header.Get("location") != "/sessions" {
+		t.Errorf("expected desktop launch page to redirect to '/sessions' for anonymous users")
+	}
+}
+
+func TestCreateDesktopSessionRedirectsForAnonymous(t *testing.T) {
+	resp, _ := testutil.RenderPage(
+		t,
+		newApp(),
+		http.MethodPost,
+		"/desktop",
+		strings.NewReader(url.Values{"desktop_type": {"xterm"}}.Encode()),
+		http.StatusSeeOther,
+		testutil.WithContentType("application/x-www-form-urlencoded"),
+	)
+
+	if resp.Header.Get("location") != "/sessions" {
+		t.Errorf("expected desktop launch to redirect to '/sessions' for anonymous users")
+	}
+}
+
+func TestNewDesktopSessionReturnsServiceUnavailableWhenToolDisabled(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o644, "#!/bin/sh\n"))
+
+	_, body := testutil.RenderPage(t, newApp(), http.MethodGet, "/desktop/new", nil, http.StatusServiceUnavailable, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	if want := "Flight Desktop is not enabled"; !strings.Contains(body, want) {
+		t.Fatalf("expected body to contain %q, got %q", want, body)
+	}
+}
+
+func TestCreateDesktopSessionReturnsServiceUnavailableWhenToolDisabled(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o644, "#!/bin/sh\n"))
+
+	_, body := testutil.RenderPage(
+		t,
+		newApp(),
+		http.MethodPost,
+		"/desktop",
+		strings.NewReader(url.Values{"desktop_type": {"xterm"}}.Encode()),
+		http.StatusServiceUnavailable,
+		testutil.WithContentType("application/x-www-form-urlencoded"),
+		testutil.WithSessionCookie(currentUser.Username, config.Session.Secret),
+	)
+
+	if want := "Flight Desktop is not enabled"; !strings.Contains(body, want) {
+		t.Fatalf("expected body to contain %q, got %q", want, body)
+	}
+}
+
+func TestNewDesktopSessionPageDisplaysAvailableTypesOrderedByIDAndSelectsFirst(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+if [ "$1" = "avail" ]; then
+cat <<'JSON'
+[
+  {
+    "id": "xterm",
+    "summary": "Minimal terminal desktop.",
+    "url": "https://example.invalid/xterm"
+  },
+  {
+    "id": "gnome",
+    "summary": "GNOME desktop.",
+    "url": "https://example.invalid/gnome"
+  }
+]
+JSON
+fi
+`))
+
+	_, body := testutil.RenderPage(t, newApp(), http.MethodGet, "/desktop/new", nil, http.StatusOK, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-back-link"]`, testutil.HasAttr("href", "/desktop"))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-type-heading--gnome"]`, testutil.HasText("gnome"))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-type-summary--gnome"]`, testutil.HasText("GNOME desktop."))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-type-url--gnome"]`, testutil.HasAttr("href", "https://example.invalid/gnome"))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-type-input--gnome"]`, testutil.HasAttr("checked", ""))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-geometry-option--1024x768"]`, testutil.HasAttr("selected", ""))
+
+	gnomeIndex := strings.Index(body, `data-testid="desktop-type-card--gnome"`)
+	xtermIndex := strings.Index(body, `data-testid="desktop-type-card--xterm"`)
+	if gnomeIndex == -1 || xtermIndex == -1 || gnomeIndex > xtermIndex {
+		t.Fatalf("expected desktop type cards to be ordered by id, got body:\n%s", body)
+	}
+}
+
+func TestDesktopSessionsPageLinksToDesktopLaunchPage(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, "#!/bin/sh\necho '[]'\n"))
+
+	_, body := testutil.RenderPage(t, newApp(), http.MethodGet, "/desktop", nil, http.StatusOK, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	testutil.AssertSelection(t, body, `[data-testid="launch-desktop-link"]`, testutil.HasAttr("href", "/desktop/new"), testutil.HasText("Launch Desktop"))
+}
+
+func TestNewDesktopSessionInvokesAvailWithJSONFormat(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	argsFile := filepath.Join(t.TempDir(), "desktop-args.txt")
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+printf '%s\n' "$@" > "`+argsFile+`"
+echo '[]'
+`))
+
+	testutil.RenderPage(t, newApp(), http.MethodGet, "/desktop/new", nil, http.StatusOK, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("failed to read command args fixture: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "avail\n--format\njson" {
+		t.Fatalf("expected avail command args, got %q", got)
+	}
+}
+
+func TestCreateDesktopSessionInvokesStartWithJSONFormatAndOmitsEmptyName(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	argsFile := filepath.Join(t.TempDir(), "desktop-args.txt")
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+printf '%s\n' "$@" > "`+argsFile+`"
+if [ "$1" = "avail" ]; then
+cat <<'JSON'
+[
+  {
+    "id": "xterm",
+    "summary": "Minimal terminal desktop.",
+    "url": "https://example.invalid/xterm"
+  }
+]
+JSON
+exit 0
+fi
+cat <<'JSON'
+{
+  "success": true,
+  "session_name": "xterm.abc123"
+}
+JSON
+`))
+
+	resp, _ := testutil.RenderPage(
+		t,
+		newApp(),
+		http.MethodPost,
+		"/desktop",
+		strings.NewReader(url.Values{
+			"desktop_type": {"xterm"},
+			"name":         {""},
+			"geometry":     {"1024x768"},
+		}.Encode()),
+		http.StatusSeeOther,
+		testutil.WithContentType("application/x-www-form-urlencoded"),
+		testutil.WithSessionCookie(currentUser.Username, config.Session.Secret),
+	)
+
+	if resp.Header.Get("location") != "/desktop" {
+		t.Fatalf("expected redirect to /desktop, got %q", resp.Header.Get("location"))
+	}
+
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("failed to read command args fixture: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "start\nxterm\n--format\njson\n--geometry\n1024x768" {
+		t.Fatalf("expected start command args without name, got %q", got)
+	}
+}
+
+func TestCreateDesktopSessionInvokesStartWithProvidedName(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	argsFile := filepath.Join(t.TempDir(), "desktop-args.txt")
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+printf '%s\n' "$@" > "`+argsFile+`"
+if [ "$1" = "avail" ]; then
+cat <<'JSON'
+[
+  {
+    "id": "xterm",
+    "summary": "Minimal terminal desktop.",
+    "url": "https://example.invalid/xterm"
+  }
+]
+JSON
+exit 0
+fi
+cat <<'JSON'
+{
+  "success": true,
+  "session_name": "named-session"
+}
+JSON
+`))
+
+	testutil.RenderPage(
+		t,
+		newApp(),
+		http.MethodPost,
+		"/desktop",
+		strings.NewReader(url.Values{
+			"desktop_type": {"xterm"},
+			"name":         {"named-session"},
+			"geometry":     {"1280x1024"},
+		}.Encode()),
+		http.StatusSeeOther,
+		testutil.WithContentType("application/x-www-form-urlencoded"),
+		testutil.WithSessionCookie(currentUser.Username, config.Session.Secret),
+	)
+
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("failed to read command args fixture: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "start\nxterm\n--format\njson\n--geometry\n1280x1024\n--name\nnamed-session" {
+		t.Fatalf("expected start command args with name, got %q", got)
+	}
+}
+
+func TestCreateDesktopSessionFailureRedisplaysFormWithPreservedValues(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+if [ "$1" = "avail" ]; then
+cat <<'JSON'
+[
+  {
+    "id": "gnome",
+    "summary": "GNOME desktop.",
+    "url": "https://example.invalid/gnome"
+  },
+  {
+    "id": "xterm",
+    "summary": "Minimal terminal desktop.",
+    "url": "https://example.invalid/xterm"
+  }
+]
+JSON
+exit 0
+fi
+cat <<'JSON'
+{
+  "success": false,
+  "session_name": "custom-session",
+  "error": "Invalid session name.",
+  "reason": "invalid_name"
+}
+JSON
+exit 1
+`))
+
+	_, body := testutil.RenderPage(
+		t,
+		newApp(),
+		http.MethodPost,
+		"/desktop",
+		strings.NewReader(url.Values{
+			"desktop_type": {"xterm"},
+			"name":         {"custom-session"},
+			"geometry":     {"1280x1024"},
+		}.Encode()),
+		http.StatusUnprocessableEntity,
+		testutil.WithContentType("application/x-www-form-urlencoded"),
+		testutil.WithSessionCookie(currentUser.Username, config.Session.Secret),
+	)
+
+	testutil.AssertSelection(t, body, `div.flash.alert`, testutil.HasText("Failed to launch desktop session."))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-name"]`, testutil.HasAttr("value", "custom-session"))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-type-input--xterm"]`, testutil.HasAttr("checked", ""))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-geometry-option--1280x1024"]`, testutil.HasAttr("selected", ""))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-name-error"]`, testutil.HasText("Invalid session name."))
+}
+
+func TestCreateDesktopSessionWithInvalidGeometryShowsInlineErrorWithoutInvokingStart(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	argsFile := filepath.Join(t.TempDir(), "desktop-args.txt")
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+printf '%s\n' "$@" >> "`+argsFile+`"
+cat <<'JSON'
+[
+  {
+    "id": "xterm",
+    "summary": "Minimal terminal desktop.",
+    "url": "https://example.invalid/xterm"
+  }
+]
+JSON
+`))
+
+	_, body := testutil.RenderPage(
+		t,
+		newApp(),
+		http.MethodPost,
+		"/desktop",
+		strings.NewReader(url.Values{
+			"desktop_type": {"xterm"},
+			"name":         {"bad-geometry"},
+			"geometry":     {"640x480"},
+		}.Encode()),
+		http.StatusUnprocessableEntity,
+		testutil.WithContentType("application/x-www-form-urlencoded"),
+		testutil.WithSessionCookie(currentUser.Username, config.Session.Secret),
+	)
+
+	testutil.AssertSelection(t, body, `div.flash.alert`, testutil.HasText("Failed to launch desktop session."))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-geometry-error"]`, testutil.HasText("Select a supported geometry."))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-name"]`, testutil.HasAttr("value", "bad-geometry"))
+
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("failed to read command args fixture: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "avail\n--format\njson" {
+		t.Fatalf("expected only avail command args, got %q", got)
+	}
+}
+
+func TestCreateDesktopSessionWithInvalidDesktopTypeShowsInlineErrorWithoutInvokingStart(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	argsFile := filepath.Join(t.TempDir(), "desktop-args.txt")
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+printf '%s\n' "$@" >> "`+argsFile+`"
+cat <<'JSON'
+[
+  {
+    "id": "xterm",
+    "summary": "Minimal terminal desktop.",
+    "url": "https://example.invalid/xterm"
+  }
+]
+JSON
+`))
+
+	_, body := testutil.RenderPage(
+		t,
+		newApp(),
+		http.MethodPost,
+		"/desktop",
+		strings.NewReader(url.Values{
+			"desktop_type": {"gnome"},
+			"name":         {"bad-type"},
+			"geometry":     {"1024x768"},
+		}.Encode()),
+		http.StatusUnprocessableEntity,
+		testutil.WithContentType("application/x-www-form-urlencoded"),
+		testutil.WithSessionCookie(currentUser.Username, config.Session.Secret),
+	)
+
+	testutil.AssertSelection(t, body, `div.flash.alert`, testutil.HasText("Failed to launch desktop session."))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-desktop-type-error"]`, testutil.HasText("Select an available desktop type."))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-name"]`, testutil.HasAttr("value", "bad-type"))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-geometry-option--1024x768"]`, testutil.HasAttr("selected", ""))
+
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("failed to read command args fixture: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "avail\n--format\njson" {
+		t.Fatalf("expected only avail command args, got %q", got)
+	}
+}

--- a/flight-web-suite/desktop_launch_functional_test.go
+++ b/flight-web-suite/desktop_launch_functional_test.go
@@ -93,7 +93,7 @@ fi
 	testutil.AssertSelection(t, body, `[data-testid="desktop-type-card--gnome"] h3`, testutil.HasText("gnome"))
 	testutil.AssertSelection(t, body, `[data-testid="desktop-type-card--gnome"] h3 + p`, testutil.HasText("GNOME desktop."))
 	testutil.AssertSelection(t, body, `[data-testid="desktop-type-card--gnome"] a`, testutil.HasAttr("href", "https://example.invalid/gnome"))
-	testutil.AssertSelection(t, body, `[data-testid="desktop-type-input--gnome"]`, testutil.HasAttr("checked", ""))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-type-card--gnome"] input[type="radio"]`, testutil.HasAttr("checked", ""))
 	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-geometry-option--1024x768"]`, testutil.HasAttr("selected", ""))
 
 	gnomeIndex := strings.Index(body, `data-testid="desktop-type-card--gnome"`)
@@ -287,7 +287,7 @@ exit 1
 
 	testutil.AssertSelection(t, body, `div.flash.alert`, testutil.HasText("Failed to launch desktop session."))
 	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-name"]`, testutil.HasAttr("value", "custom-session"))
-	testutil.AssertSelection(t, body, `[data-testid="desktop-type-input--xterm"]`, testutil.HasAttr("checked", ""))
+	testutil.AssertSelection(t, body, `[data-testid="desktop-type-card--xterm"] input[type="radio"]`, testutil.HasAttr("checked", ""))
 	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-geometry-option--1280x1024"]`, testutil.HasAttr("selected", ""))
 	testutil.AssertSelection(t, body, `[data-testid="desktop-launch-name-error"]`, testutil.HasText("Invalid session name."))
 }

--- a/flight-web-suite/desktop_launch_integration_test.go
+++ b/flight-web-suite/desktop_launch_integration_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/concertim/flight-user-suite/flight-web-suite/internal/testutil"
+)
+
+func TestCreateDesktopSessionSuccessAddsFlashAndRedirects(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setAuthenticatorPathForTest(t, filepath.Join("testdata", "authenticator_success.sh"))
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+if [ "$1" = "list" ]; then
+  echo '[]'
+  exit 0
+fi
+if [ "$1" = "avail" ]; then
+cat <<'JSON'
+[
+  {
+    "id": "xterm",
+    "summary": "Minimal terminal desktop.",
+    "url": "https://example.invalid/xterm"
+  }
+]
+JSON
+  exit 0
+fi
+cat <<'JSON'
+{
+  "success": true,
+  "session_name": "named-session"
+}
+JSON
+`))
+
+	srv, client := testutil.SetupIntegrationServer(t, newApp())
+	client.PostForm(srv.URL+"/sessions", url.Values{
+		"username": {currentUser.Username},
+		"password": {"fakepassword"},
+	})
+	client.FollowRedirect()
+	client.PostForm(srv.URL+"/desktop", url.Values{
+		"desktop_type": {"xterm"},
+		"name":         {"named-session"},
+		"geometry":     {"1024x768"},
+	})
+
+	client.AssertRedirect(t, http.StatusSeeOther, "/desktop")
+	_, body := client.FollowRedirect()
+	testutil.AssertSelection(t, body, `div.flash.notice`,
+		testutil.HasText("Desktop session 'named-session' launched."),
+	)
+}
+
+func TestCreateDesktopSessionFailureAddsFlashAndRedisplaysForm(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setAuthenticatorPathForTest(t, filepath.Join("testdata", "authenticator_success.sh"))
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+if [ "$1" = "avail" ]; then
+cat <<'JSON'
+[
+  {
+    "id": "xterm",
+    "summary": "Minimal terminal desktop.",
+    "url": "https://example.invalid/xterm"
+  }
+]
+JSON
+  exit 0
+fi
+cat <<'JSON'
+{
+  "success": false,
+  "session_name": "named-session",
+  "error": "Desktop startup failed.",
+  "reason": "start_failed"
+}
+JSON
+exit 1
+`))
+
+	srv, client := testutil.SetupIntegrationServer(t, newApp())
+	client.PostForm(srv.URL+"/sessions", url.Values{
+		"username": {currentUser.Username},
+		"password": {"fakepassword"},
+	})
+	client.FollowRedirect()
+	_, body := client.PostForm(srv.URL+"/desktop", url.Values{
+		"desktop_type": {"xterm"},
+		"name":         {"named-session"},
+		"geometry":     {"1024x768"},
+	})
+
+	client.AssertResponseCode(t, http.StatusUnprocessableEntity)
+	testutil.AssertSelection(t, body, `div.flash.alert`,
+		testutil.HasText("Desktop startup failed."),
+	)
+}

--- a/flight-web-suite/desktop_launch_integration_test.go
+++ b/flight-web-suite/desktop_launch_integration_test.go
@@ -74,10 +74,13 @@ JSON
 fi
 cat <<'JSON'
 {
-  "success": false,
-  "session_name": "named-session",
-  "error": "Desktop startup failed.",
-  "reason": "start_failed"
+  "errors": [
+    {
+      "code": "start_failed",
+      "title": "Desktop session failed to start",
+      "detail": "Desktop startup failed."
+    }
+  ]
 }
 JSON
 exit 1
@@ -97,6 +100,6 @@ exit 1
 
 	client.AssertResponseCode(t, http.StatusUnprocessableEntity)
 	testutil.AssertSelection(t, body, `div.flash.alert`,
-		testutil.HasText("Desktop startup failed."),
+		testutil.HasText("Failed to launch desktop session."),
 	)
 }

--- a/flight-web-suite/desktop_sessions.go
+++ b/flight-web-suite/desktop_sessions.go
@@ -1,31 +1,14 @@
 package main
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
-	"os/exec"
-	"os/user"
-	"path/filepath"
 	"slices"
-	"strconv"
 	"strings"
-	"syscall"
-	"time"
 
+	"github.com/concertim/flight-user-suite/flight-web-suite/desktop"
 	"github.com/labstack/echo/v5"
 )
-
-type desktopSession struct {
-	Name        string    `json:"name"`
-	DesktopType string    `json:"desktop_type"`
-	State       string    `json:"state"`
-	Host        string    `json:"host"`
-	CreatedAt   time.Time `json:"created_at"`
-}
 
 type desktopSessionCard struct {
 	Name          string
@@ -46,12 +29,12 @@ func indexDesktopSessionsHandler(c *echo.Context) error {
 		return err
 	}
 
-	sessions, err := desktopListCommand(c.Request().Context(), CurrentUserName(c))
+	sessions, err := desktop.ListCommand(c.Request().Context(), env, CurrentUserName(c))
 	if err != nil {
 		return err
 	}
 
-	slices.SortFunc(sessions, func(a, b desktopSession) int {
+	slices.SortFunc(sessions, func(a, b *desktop.Session) int {
 		if byName := strings.Compare(a.Name, b.Name); byName != 0 {
 			return byName
 		}
@@ -73,7 +56,7 @@ func destroyDesktopSessionHandler(c *echo.Context) error {
 		return err
 	}
 
-	response, err := desktopKillCommand(c.Request().Context(), CurrentUserName(c), c.Param("sessionName"))
+	response, err := desktop.KillCommand(c.Request().Context(), env, CurrentUserName(c), c.Param("sessionName"))
 	if err != nil {
 		return err
 	}
@@ -91,7 +74,7 @@ func destroyDesktopSessionHandler(c *echo.Context) error {
 	return c.Redirect(http.StatusSeeOther, "/desktop")
 }
 
-func buildDesktopSessionCards(sessions []desktopSession) []desktopSessionCard {
+func buildDesktopSessionCards(sessions []*desktop.Session) []desktopSessionCard {
 	cards := make([]desktopSessionCard, 0, len(sessions))
 	for _, session := range sessions {
 		actionLabel := "Clean"
@@ -121,7 +104,7 @@ func buildDesktopSessionCards(sessions []desktopSession) []desktopSessionCard {
 	return cards
 }
 
-func desktopSessionsSummary(sessions []desktopSession) string {
+func desktopSessionsSummary(sessions []*desktop.Session) string {
 	count := len(sessions)
 	runningCount := 0
 	if count == 0 {
@@ -153,134 +136,4 @@ func desktopSessionsSummary(sessions []desktopSession) string {
 		return fmt.Sprintf("You have 1 desktop session currently running %s", nonRunningString)
 	}
 	return fmt.Sprintf("You have %d desktop sessions currently running %s", runningCount, nonRunningString)
-}
-
-func desktopListCommand(ctx context.Context, username string) ([]desktopSession, error) {
-	cmd, err := buildDesktopCommand(ctx, username, "list", "--format", "json")
-	if err != nil {
-		return nil, err
-	}
-
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		if stderr.Len() != 0 {
-			return nil, fmt.Errorf("listing desktop sessions: %s", stderr.String())
-		}
-		return nil, fmt.Errorf("listing desktop sessions: %w", err)
-	}
-
-	var sessions []desktopSession
-	if err := json.Unmarshal(stdout.Bytes(), &sessions); err != nil {
-		return nil, fmt.Errorf("decoding desktop sessions: %w", err)
-	}
-	return sessions, nil
-}
-
-type terminationResponse struct {
-	Success     bool   `json:"success"`
-	SessionName string `json:"session_name"`
-	Error       string `json:"error"`
-	Reason      string `json:"reason"`
-}
-
-func desktopKillCommand(ctx context.Context, username, sessionName string) (terminationResponse, error) {
-	cmd, err := buildDesktopCommand(ctx, username, "kill", "--format", "json", "--", sessionName)
-	if err != nil {
-		return terminationResponse{}, err
-	}
-
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	runErr := cmd.Run()
-
-	var response terminationResponse
-	if decodeErr := json.Unmarshal(stdout.Bytes(), &response); decodeErr == nil {
-		return response, nil
-	}
-
-	if runErr != nil {
-		if stderr.Len() != 0 {
-			return terminationResponse{}, fmt.Errorf("terminating desktop session: %s", stderr.String())
-		}
-		return terminationResponse{}, fmt.Errorf("terminating desktop session: %w", runErr)
-	}
-	return terminationResponse{}, fmt.Errorf("decoding desktop termination response: %s", stdout.String())
-}
-
-func buildDesktopCommand(ctx context.Context, username string, args ...string) (*exec.Cmd, error) {
-	userInfo, err := user.Lookup(username)
-	if err != nil {
-		return nil, fmt.Errorf("looking up user %q: %w", username, err)
-	}
-
-	uid, err := strconv.Atoi(userInfo.Uid)
-	if err != nil {
-		return nil, fmt.Errorf("parsing uid for user %q: %w", userInfo.Username, err)
-	}
-	gid, err := strconv.Atoi(userInfo.Gid)
-	if err != nil {
-		return nil, fmt.Errorf("parsing gid for user %q: %w", userInfo.Username, err)
-	}
-
-	groupIDs, err := userInfo.GroupIds()
-	if err != nil {
-		return nil, fmt.Errorf("looking up groups for user %q: %w", userInfo.Username, err)
-	}
-	groups := make([]uint32, 0, len(groupIDs))
-	for _, groupID := range groupIDs {
-		parsed, err := strconv.Atoi(groupID)
-		if err != nil {
-			return nil, fmt.Errorf("parsing group id %q for user %q: %w", groupID, userInfo.Username, err)
-		}
-		groups = append(groups, uint32(parsed))
-	}
-
-	cmd := exec.CommandContext(ctx, desktopToolPath(), args...)
-	cmd.Dir = userInfo.HomeDir
-	cmd.Env = desktopCommandEnv(userInfo)
-	if os.Geteuid() == 0 {
-		cmd.SysProcAttr = &syscall.SysProcAttr{
-			Credential: &syscall.Credential{
-				Uid:    uint32(uid),
-				Gid:    uint32(gid),
-				Groups: groups,
-			},
-		}
-	} else if os.Geteuid() != uid {
-		return nil, fmt.Errorf("cannot run desktop listing as %q without root privileges", userInfo.Username)
-	}
-	return cmd, nil
-}
-
-func desktopToolPath() string {
-	return filepath.Join(env.FlightRoot, "usr", "lib", "flight-core", "flight-desktop")
-}
-
-func desktopCommandEnv(userInfo *user.User) []string {
-	env := slices.Clone(os.Environ())
-	env = slices.DeleteFunc(env, func(envar string) bool {
-		parts := strings.SplitN(envar, "=", 2)
-		name := parts[0]
-		return strings.HasPrefix(name, "XDG_")
-	})
-	env = upsertEnv(env, "HOME", userInfo.HomeDir)
-	env = upsertEnv(env, "LOGNAME", userInfo.Username)
-	env = upsertEnv(env, "USER", userInfo.Username)
-	return env
-}
-
-func upsertEnv(env []string, key, value string) []string {
-	prefix := key + "="
-	for i, entry := range env {
-		if strings.HasPrefix(entry, prefix) {
-			env[i] = prefix + value
-			return env
-		}
-	}
-	return append(env, prefix+value)
 }

--- a/flight-web-suite/desktop_sessions.go
+++ b/flight-web-suite/desktop_sessions.go
@@ -16,7 +16,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/concertim/flight-user-suite/flight/toolset"
 	"github.com/labstack/echo/v5"
 )
 
@@ -43,10 +42,8 @@ func indexDesktopSessionsHandler(c *echo.Context) error {
 	if !IsLoggedIn(c) {
 		return c.Redirect(http.StatusSeeOther, "/sessions")
 	}
-
-	tool, err := toolset.GetTool(env.FlightRoot, "desktop")
-	if err != nil || !tool.Enabled {
-		return echo.NewHTTPError(http.StatusServiceUnavailable, "Flight Desktop is not enabled")
+	if err := requireDesktopToolEnabled(); err != nil {
+		return err
 	}
 
 	sessions, err := desktopListCommand(c.Request().Context(), CurrentUserName(c))
@@ -72,10 +69,8 @@ func destroyDesktopSessionHandler(c *echo.Context) error {
 	if !IsLoggedIn(c) {
 		return c.Redirect(http.StatusSeeOther, "/sessions")
 	}
-
-	tool, err := toolset.GetTool(env.FlightRoot, "desktop")
-	if err != nil || !tool.Enabled {
-		return echo.NewHTTPError(http.StatusServiceUnavailable, "Flight Desktop is not enabled")
+	if err := requireDesktopToolEnabled(); err != nil {
+		return err
 	}
 
 	response, err := desktopKillCommand(c.Request().Context(), CurrentUserName(c), c.Param("sessionName"))

--- a/flight-web-suite/main.go
+++ b/flight-web-suite/main.go
@@ -108,6 +108,8 @@ func newApp() *echo.Echo {
 		return c.Render(http.StatusOK, "home", AddCommonData(c, data))
 	})
 	e.GET("/desktop", indexDesktopSessionsHandler)
+	e.GET("/desktop/new", newDesktopSessionHandler)
+	e.POST("/desktop", createDesktopSessionHandler)
 	e.DELETE("/desktop/:sessionName", destroyDesktopSessionHandler)
 	e.GET("/sessions", newSessionHandler)
 	e.POST("/sessions", createSessionHandler)

--- a/flight-web-suite/views/desktop/index.gohtml
+++ b/flight-web-suite/views/desktop/index.gohtml
@@ -1,8 +1,14 @@
 {{define "desktop/index"}}
 {{template "layouts.application.start" . }}
 
-<h1 class="mt-20 mb-6">Desktop Sessions</h1>
-<p class="mb-8" data-testid="desktop-sessions-summary">{{ .Summary }}</p>
+<div class="mt-20 mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+    <div class="flex-grow">
+        <h1 class="mb-2">Desktop Sessions</h1>
+        <p data-testid="desktop-sessions-summary">{{ .Summary }}</p>
+    </div>
+    <a class="inline-flex items-center justify-center border border-alces-blue bg-alces-blue px-4 py-2 text-white"
+        href="/desktop/new" data-testid="launch-desktop-link">Launch Desktop</a>
+</div>
 
 <div class="grid grid-cols-1 gap-4 xl:grid-cols-2 2xl:grid-cols-3" data-testid="desktop-session-cards">
     {{range .DesktopSessions}}

--- a/flight-web-suite/views/desktop/new.gohtml
+++ b/flight-web-suite/views/desktop/new.gohtml
@@ -27,7 +27,7 @@
                     {{range .DesktopTypes}}
                     <div class="grid grid-rows-subgrid" data-testid="desktop-type-card--{{ .ID }}">
                         <input type="radio" name="desktop_type" id="{{ .ID }}" value="{{ .ID }}" class="sr-only peer"
-                            {{if eq $.Form.DesktopType .ID}}checked{{end}} data-testid="desktop-type-input--{{ .ID }}">
+                            {{if eq $.Form.DesktopType .ID}}checked{{end}}>
                         <label for="{{ .ID }}"
                             class="flex flex-col justify-between cursor-pointer border p-5 transition max-w-xs border-slate-300 bg-white peer-checked:border-alces-blue peer-checked:bg-sky-50">
                             <div class="flex items-start justify-between gap-4">

--- a/flight-web-suite/views/desktop/new.gohtml
+++ b/flight-web-suite/views/desktop/new.gohtml
@@ -1,0 +1,101 @@
+{{define "desktop/new"}}
+{{template "layouts.application.start" . }}
+
+<div class="mx-auto mt-6 max-w-5xl text-left">
+    <a href="/desktop" class="inline-flex items-center gap-2 text-sm text-slate-500"
+        data-testid="desktop-launch-back-link">← Back to desktops</a>
+
+    <div class="mt-6 flex flex-col gap-y-6 items-start lg:items-center">
+        <div class="mt-2">
+            <h1 class="">Launch a desktop session</h1>
+            <p class="mt-1 max-w-2xl text-base text-slate-700">
+                Select your desktop type from the options below.
+            </p>
+        </div>
+
+        <form action="/desktop" method="post" class="mt-8 flex flex-col items-start md:items-center space-y-12"
+            data-testid="desktop-launch-form">
+            <section>
+                <div class="mb-3 flex items-end justify-between gap-4">
+                    {{if .Form.Errors.DesktopType}}
+                    <p class="text-sm text-red-700" data-testid="desktop-launch-desktop-type-error">{{
+                        .Form.Errors.DesktopType }}</p>
+                    {{end}}
+                </div>
+
+                <div class="grid gap-4 md:grid-cols-2" data-testid="desktop-type-cards">
+                    {{range .DesktopTypes}}
+                    <div class="grid grid-rows-subgrid" data-testid="desktop-type-card--{{ .ID }}">
+                        <input type="radio" name="desktop_type" id="{{ .ID }}" value="{{ .ID }}" class="sr-only peer"
+                            {{if eq $.Form.DesktopType .ID}}checked{{end}} data-testid="desktop-type-input--{{ .ID }}">
+                        <label for="{{ .ID }}"
+                            class="flex flex-col justify-between cursor-pointer border p-5 transition max-w-xs border-slate-300 bg-white peer-checked:border-alces-blue peer-checked:bg-sky-50">
+                            <div class="flex items-start justify-between gap-4">
+                                <div>
+                                    <h3 class="text-xl font-semibold" data-testid="desktop-type-heading--{{ .ID }}">{{
+                                        .ID }}</h3>
+                                    <p class="mt-3 text-sm leading-6 text-slate-700"
+                                        data-testid="desktop-type-summary--{{ .ID }}">{{ .Summary }}</p>
+                                </div>
+                            </div>
+                            {{if .URL}}
+                            <p class="mt-4 text-sm">
+                                <a href="{{ .URL }}" class="text-alces-blue underline"
+                                    data-testid="desktop-type-url--{{ .ID }}">Project page</a>
+                            </p>
+                            {{end}}
+                        </label>
+                    </div>
+                    {{end}}
+                </div>
+            </section>
+
+            <div class="flex flex-col items-start md:items-center">
+                <label for="desktop-launch-name" class="block text-sm">
+                    Name your session <span class="font-normal text-slate-500">(optional).</span>
+                </label>
+                <input id="desktop-launch-name" name="name" type="text" value="{{ .Form.Name }}"
+                    class="mt-2 w-md border border-slate-300 px-3 py-2" data-testid="desktop-launch-name">
+                {{if .Form.Errors.Name}}
+                <p class="mt-2 text-sm text-red-700" data-testid="desktop-launch-name-error">{{
+                    .Form.Errors.Name }}</p>
+                {{end}}
+            </div>
+
+            <div class="flex flex-col items-start md:items-center">
+                <label for="desktop-launch-geometry" class="block text-sm">
+                    Select your desktop resolution.
+                </label>
+                <select id="desktop-launch-geometry" name="geometry"
+                    class="mt-2 w-full border border-slate-300 bg-white px-3 py-2"
+                    data-testid="desktop-launch-geometry">
+                    {{range .GeometryOptions}}
+                    <option value="{{ .Value }}" {{if eq $.Form.Geometry .Value}}selected{{end}}
+                        data-testid="desktop-launch-geometry-option--{{ .Value }}">{{ .Label }}</option>
+                    {{end}}
+                </select>
+                {{if .Form.Errors.Geometry}}
+                <p class="mt-2 text-sm text-red-700" data-testid="desktop-launch-geometry-error">{{
+                    .Form.Errors.Geometry }}</p>
+                {{end}}
+            </div>
+
+            <button type="submit"
+                class="cursor-pointer border border-alces-blue bg-alces-blue px-10 py-2 font-semibold text-white"
+                data-testid="desktop-launch-submit">LAUNCH</button>
+        </form>
+
+        {{if false }}
+        <aside class="border border-alces-blue-light bg-sky-50 p-6">
+            <h2 class="text-lg font-semibold">Session Details</h2>
+            <p class="mt-3 text-sm leading-7 text-slate-700">
+                Desktop sessions run locally for your account. Pick a desktop type that suits your workload, then start
+                a new session with the default geometry or a larger layout.
+            </p>
+        </aside>
+        {{end}}
+    </div>
+</div>
+
+{{template "layouts.application.end" . }}
+{{end}}

--- a/flight-web-suite/views/desktop/new.gohtml
+++ b/flight-web-suite/views/desktop/new.gohtml
@@ -32,16 +32,13 @@
                             class="flex flex-col justify-between cursor-pointer border p-5 transition max-w-xs border-slate-300 bg-white peer-checked:border-alces-blue peer-checked:bg-sky-50">
                             <div class="flex items-start justify-between gap-4">
                                 <div>
-                                    <h3 class="text-xl font-semibold" data-testid="desktop-type-heading--{{ .ID }}">{{
-                                        .ID }}</h3>
-                                    <p class="mt-3 text-sm leading-6 text-slate-700"
-                                        data-testid="desktop-type-summary--{{ .ID }}">{{ .Summary }}</p>
+                                    <h3 class="text-xl font-semibold">{{ .ID }}</h3>
+                                    <p class="mt-3 text-sm leading-6 text-slate-700">{{ .Summary }}</p>
                                 </div>
                             </div>
                             {{if .URL}}
                             <p class="mt-4 text-sm">
-                                <a href="{{ .URL }}" class="text-alces-blue underline"
-                                    data-testid="desktop-type-url--{{ .ID }}">Project page</a>
+                                <a href="{{ .URL }}" class="text-alces-blue underline">Project page</a>
                             </p>
                             {{end}}
                         </label>


### PR DESCRIPTION
This PR adds support to web suite to launch local desktop sessions.

[Screencast from 2026-04-24 13-21-42.webm](https://github.com/user-attachments/assets/7e57a8c3-551c-4b56-8c2b-167cd5327eff)


It does that by teaching `flight desktop avail` to return machine-readable JSON, then using that API to build a new launch form.  The `flight desktop start` command has also learned to return machine-readable JSON and is used when processing the submitted form.

The JSON output schema for `flight start` is more involved than it is for other commands as it has a number of failure paths, some of which are exercised by user provided input and others that are not.  The more complicated error schema allows the web UI to present structured, user-appropriate failures instead of raw CLI messages. The error format is modeled loosely on JSON:API error objects, so should be reasonably familiar.

The web-side desktop command integration has been extracted into a dedicated package.

### Limitations

- Available geometries are a hardcoded list.
- The web flow currently calls `desktop avail` twice: once to render the form and again to validate submitted desktop type input.  This is fast enough that it might not be a problem.
- The most likely user-correctable launch failure is still an invalid name; dependency-related failures are only reported after submission.

### Possible enhancements

- Improve handling for missing global desktop dependencies, possibly by disabling the form.
- Improve handling for missing type-specific dependencies, possibly by disabling or hiding affected desktop types.
- Derive supported geometries dynamically, for example via xrandr.
- Add client-side validation for session-name format.
