### PR TITLE
[Flight Web - Desktop] can clean stale desktops

### DIFF
--- a/flight-desktop/session.go
+++ b/flight-desktop/session.go
@@ -184,7 +184,7 @@ func (s Session) PrimaryIP() netip.Addr {
 }
 
 func (s *Session) SessionState() sessionState {
-	if !s.IsLocal() {
+	if s.State != Broken && !s.IsLocal() {
 		return Remote
 	}
 	return s.State

--- a/flight-desktop/session.go
+++ b/flight-desktop/session.go
@@ -91,11 +91,16 @@ func loadSession(name string) (*Session, error) {
 		session.State = Broken
 		return session, nil
 	}
-	if !session.isActive() {
-		session.State = Exited
-	}
 	// Make certain that name isn't overridden by a value in the metadata file.
 	session.Name = name
+	if session.IP == "" {
+		log.Debug("Session metadata does not contain IP. Session is broken.", "metadataFile", session.metadataFile())
+		session.State = Broken
+		return session, nil
+	}
+	if session.isLocal() && !session.isActive() {
+		session.State = Exited
+	}
 	return session, nil
 }
 
@@ -183,14 +188,23 @@ func (s Session) PrimaryIP() netip.Addr {
 	return ip
 }
 
-func (s *Session) SessionState() sessionState {
-	if s.State != Broken && !s.IsLocal() {
+// ComputedState returns the sessions state taking into account whether it is
+// broken or running on a remote machine.
+//
+// NOTE: Use this method in preference to [Session.State] or [Session.isLocal]
+func (s *Session) ComputedState() sessionState {
+	if s.State != Broken && !s.isLocal() {
 		return Remote
 	}
 	return s.State
 }
 
-func (s *Session) IsLocal() bool {
+// isLocal returns true if the VNC sesssion is running on the same machine is
+// this process.
+//
+// If the session's State is Broken, the response is undefined. A safer option
+// is to call [Session.ComputedState].
+func (s *Session) isLocal() bool {
 	return s.IP == s.PrimaryIP().String()
 }
 
@@ -204,7 +218,7 @@ func (s Session) Port() int {
 }
 
 func (s Session) PrimaryConnectionString() string {
-	if s.State == Broken {
+	if s.State == Broken || s.IP == "" || s.Port() == -1 {
 		return ""
 	}
 	return fmt.Sprintf("%s:%d", s.IP, s.Port())

--- a/flight-desktop/session_clean.go
+++ b/flight-desktop/session_clean.go
@@ -63,7 +63,7 @@ You can specify which sessions are cleaned by providing the optional <id> parame
 			skipped := make([]*Session, 0)
 
 			for _, session := range sessions {
-                                if session.SessionState() == Remote || session.SessionState() == Active {
+				if session.ComputedState() == Remote || session.ComputedState() == Active {
 					skipped = append(skipped, session)
 				} else {
 					err := session.RemoveSessionDir()
@@ -131,7 +131,7 @@ func completeExitedSessionNames(ctx context.Context, cmd *cli.Command) {
 			return
 		}
 		for _, session := range sessions {
-			if session.SessionState() == Exited || session.SessionState() == Broken {
+			if session.ComputedState() == Exited || session.ComputedState() == Broken {
 				fmt.Println(session.Name)
 			}
 		}

--- a/flight-desktop/session_clean.go
+++ b/flight-desktop/session_clean.go
@@ -15,7 +15,7 @@ import (
 func cleanSessionCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "clean",
-		Usage: "Clean up one or more exited desktop sessions",
+		Usage: "Clean up one or more exited or broken desktop sessions",
 		Description: wordwrap.String(`Remove one or more desktop session directories for exited or broken desktop sessions.
 
 Depending on how cleanly desktop sessions exit, the session directory may be retained and require manual cleaning.  Desktops that are cleanly exited or manually terminated using the 'kill' command are automatically cleaned when the exit.
@@ -63,7 +63,7 @@ You can specify which sessions are cleaned by providing the optional <id> parame
 			skipped := make([]*Session, 0)
 
 			for _, session := range sessions {
-				if !session.IsLocal() || session.State == Active {
+                                if session.SessionState() == Remote || session.SessionState() == Active {
 					skipped = append(skipped, session)
 				} else {
 					err := session.RemoveSessionDir()
@@ -88,7 +88,7 @@ You can specify which sessions are cleaned by providing the optional <id> parame
 				}
 				out = lipgloss.JoinVertical(
 					lipgloss.Left,
-					append([]string{out, cliui.Header.Render("Cleaned exited sessions")}, coloured...)...,
+					append([]string{out, cliui.Header.Render("Cleaned sessions")}, coloured...)...,
 				)
 			}
 			if len(failed) > 0 {
@@ -131,7 +131,7 @@ func completeExitedSessionNames(ctx context.Context, cmd *cli.Command) {
 			return
 		}
 		for _, session := range sessions {
-			if session.SessionState() == Exited {
+			if session.SessionState() == Exited || session.SessionState() == Broken {
 				fmt.Println(session.Name)
 			}
 		}

--- a/flight-desktop/session_clean.go
+++ b/flight-desktop/session_clean.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"charm.land/lipgloss/v2"
@@ -26,6 +29,7 @@ You can specify which sessions are cleaned by providing the optional <id> parame
 		Arguments: []cli.Argument{
 			&cli.StringArgs{Name: "id", UsageText: "[<id>...]", Min: 0, Max: -1},
 		},
+		Flags:         []cli.Flag{formatFlag},
 		ShellComplete: completeExitedSessionNames,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			ids := cmd.StringArgs("id")
@@ -43,83 +47,191 @@ You can specify which sessions are cleaned by providing the optional <id> parame
 					sessions = append(sessions, session)
 				}
 			}
-			p := pin.New("Cleaning desktop sessions",
-				pin.WithSpinnerColor(pin.ColorCyan),
-				pin.WithTextColor(pin.ColorGreen),
-				pin.WithDoneSymbol('\u2705'),
-				pin.WithFailSymbol('\u274c'),
-				pin.WithFailColor(pin.ColorRed),
-			)
-			cancel := p.Start(ctx)
-			defer cancel()
-			timer := time.After(1 * time.Second)
 
-			var firstErr error
-			skippedStyle := lipgloss.NewStyle().Foreground(cliui.LightDark(cliui.Primary, cliui.Cream)).MarginLeft(1)
-			cleanedStyle := lipgloss.NewStyle().Foreground(lipgloss.Green).MarginLeft(1)
-			failedStyle := lipgloss.NewStyle().Foreground(lipgloss.Red).MarginLeft(1)
-			cleaned := make([]*Session, 0)
-			failed := make([]*Session, 0)
-			skipped := make([]*Session, 0)
-
-			for _, session := range sessions {
-				if session.ComputedState() == Remote || session.ComputedState() == Active {
-					skipped = append(skipped, session)
-				} else {
-					err := session.RemoveSessionDir()
-					if err != nil {
-						failed = append(failed, session)
-						if firstErr == nil {
-							firstErr = err
-						}
-					} else {
-						cleaned = append(cleaned, session)
-					}
-				}
+			if cmd.String("format") == "json" {
+				return cleanSessionJSON(sessions, len(ids) > 0)
 			}
-
-			<-timer
-
-			var out string
-			if len(cleaned) > 0 {
-				coloured := make([]string, 0, len(cleaned))
-				for _, session := range cleaned {
-					coloured = append(coloured, cleanedStyle.Render(session.Name))
-				}
-				out = lipgloss.JoinVertical(
-					lipgloss.Left,
-					append([]string{out, cliui.Header.Render("Cleaned sessions")}, coloured...)...,
-				)
-			}
-			if len(failed) > 0 {
-				coloured := make([]string, 0, len(failed))
-				for _, session := range failed {
-					coloured = append(coloured, failedStyle.Render(session.Name))
-				}
-				out = lipgloss.JoinVertical(
-					lipgloss.Left,
-					append([]string{out, cliui.Header.Render("Failed to clean")}, coloured...)...,
-				)
-			}
-			if len(skipped) > 0 {
-				coloured := make([]string, 0, len(skipped))
-				for _, session := range skipped {
-					coloured = append(coloured, skippedStyle.Render(session.Name))
-				}
-				out = lipgloss.JoinVertical(
-					lipgloss.Left,
-					append([]string{out, cliui.Header.Render("Skipped active/remote sessions")}, coloured...)...,
-				)
-			}
-
-			if firstErr != nil {
-				p.Fail("Cleaning failed")
-			} else {
-				p.Stop("Cleaning complete")
-			}
-			lipgloss.Println(out)
-			return firstErr
+			return cleanSessionPretty(ctx, sessions)
 		},
+	}
+}
+
+func cleanSessionPretty(ctx context.Context, sessions []*Session) error {
+	p := pin.New("Cleaning desktop sessions",
+		pin.WithSpinnerColor(pin.ColorCyan),
+		pin.WithTextColor(pin.ColorGreen),
+		pin.WithDoneSymbol('\u2705'),
+		pin.WithFailSymbol('\u274c'),
+		pin.WithFailColor(pin.ColorRed),
+	)
+	cancel := p.Start(ctx)
+	defer cancel()
+	timer := time.After(1 * time.Second)
+
+	var firstErr error
+	skippedStyle := lipgloss.NewStyle().Foreground(cliui.LightDark(cliui.Primary, cliui.Cream)).MarginLeft(1)
+	cleanedStyle := lipgloss.NewStyle().Foreground(lipgloss.Green).MarginLeft(1)
+	failedStyle := lipgloss.NewStyle().Foreground(lipgloss.Red).MarginLeft(1)
+	cleaned := make([]*Session, 0)
+	failed := make([]*Session, 0)
+	skipped := make([]*Session, 0)
+
+	for _, session := range sessions {
+		if session.ComputedState() == Remote || session.ComputedState() == Active {
+			skipped = append(skipped, session)
+		} else {
+			err := session.RemoveSessionDir()
+			if err != nil {
+				failed = append(failed, session)
+				if firstErr == nil {
+					firstErr = err
+				}
+			} else {
+				cleaned = append(cleaned, session)
+			}
+		}
+	}
+
+	<-timer
+
+	var out string
+	if len(cleaned) > 0 {
+		coloured := make([]string, 0, len(cleaned))
+		for _, session := range cleaned {
+			coloured = append(coloured, cleanedStyle.Render(session.Name))
+		}
+		out = lipgloss.JoinVertical(
+			lipgloss.Left,
+			append([]string{out, cliui.Header.Render("Cleaned sessions")}, coloured...)...,
+		)
+	}
+	if len(failed) > 0 {
+		coloured := make([]string, 0, len(failed))
+		for _, session := range failed {
+			coloured = append(coloured, failedStyle.Render(session.Name))
+		}
+		out = lipgloss.JoinVertical(
+			lipgloss.Left,
+			append([]string{out, cliui.Header.Render("Failed to clean")}, coloured...)...,
+		)
+	}
+	if len(skipped) > 0 {
+		coloured := make([]string, 0, len(skipped))
+		for _, session := range skipped {
+			coloured = append(coloured, skippedStyle.Render(session.Name))
+		}
+		out = lipgloss.JoinVertical(
+			lipgloss.Left,
+			append([]string{out, cliui.Header.Render("Skipped active/remote sessions")}, coloured...)...,
+		)
+	}
+
+	if firstErr != nil {
+		p.Fail("Cleaning failed")
+	} else {
+		p.Stop("Cleaning complete")
+	}
+	lipgloss.Println(out)
+	return firstErr
+}
+
+type cleanResult struct {
+	Success     bool   `json:"success"`
+	SessionName string `json:"session_name"`
+	Error       string `json:"error,omitempty"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+type cleanCommandResponse struct {
+	Success bool          `json:"success"`
+	Results []cleanResult `json:"results"`
+}
+
+func cleanSessionJSON(sessions []*Session, namedSessionsOnly bool) error {
+	results := make([]cleanResult, 0, len(sessions))
+	allSucceeded := true
+
+	if namedSessionsOnly {
+		// We're cleaning an explicitly named set of sessions.
+		for _, session := range sessions {
+			result := cleanSingleSession(session)
+			results = append(results, result)
+			if !result.Success {
+				allSucceeded = false
+			}
+		}
+	} else {
+		// We're cleaning all sessions that can be cleaned.
+		for _, session := range sessions {
+			if session.ComputedState() == Remote || session.ComputedState() == Active {
+				// No sessions have been explicitly specified - we're cleaning
+				// all possible sessions. Remote and active sessions should be
+				// silently ignored.
+				continue
+			}
+			result := cleanSingleSession(session)
+			results = append(results, result)
+			if !result.Success {
+				allSucceeded = false
+			}
+		}
+	}
+
+	return writeCleanResponse(cleanCommandResponse{
+		Success: allSucceeded,
+		Results: results,
+	})
+}
+
+func cleanSingleSession(session *Session) cleanResult {
+	// Guard against sessions we're not going to clean.
+	//
+	// We do not clean active sessions, and we cannot determine if a remote
+	// session is active so we don't clean them either.
+
+	switch session.ComputedState() {
+	case Remote:
+		return cleanResult{
+			Success:     false,
+			SessionName: session.Name,
+			Error:       fmt.Sprintf("Desktop session '%s' is not local.", session.Name),
+			Reason:      "not_local",
+		}
+	case Active:
+		return cleanResult{
+			Success:     false,
+			SessionName: session.Name,
+			Error:       fmt.Sprintf("Desktop session '%s' is active.", session.Name),
+			Reason:      "active",
+		}
+	}
+
+	if err := session.RemoveSessionDir(); err != nil {
+		return cleanResult{
+			Success:     false,
+			SessionName: session.Name,
+			Error:       fmt.Sprintf("Cleaning session '%s' failed.", session.Name),
+			Reason:      "clean_failed",
+		}
+	}
+	return cleanResult{
+		Success:     true,
+		SessionName: session.Name,
+	}
+}
+
+func writeCleanResponse(response cleanCommandResponse) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(response); err != nil {
+		return err
+	}
+	if response.Success {
+		return nil
+	}
+	return SilentExitError{
+		ExitCode:  1,
+		exitError: errors.New("session cleaning failed"),
 	}
 }
 

--- a/flight-desktop/session_clean_test.go
+++ b/flight-desktop/session_clean_test.go
@@ -1,0 +1,193 @@
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type cleanCommandResponse struct {
+	Success bool                 `json:"success"`
+	Results []cleanCommandResult `json:"results"`
+}
+
+type cleanCommandResult struct {
+	Success     bool   `json:"success"`
+	SessionName string `json:"session_name"`
+	Error       string `json:"error,omitempty"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+func TestCleanSessionJSON(t *testing.T) {
+	tests := []struct {
+		name             string
+		sessionName      string
+		setup            func(t *testing.T)
+		expectedResponse cleanCommandResponse
+		expectedExitCode int
+		expectRemoved    bool
+	}{
+		{
+			name:        "success",
+			sessionName: "alpha",
+			setup: func(t *testing.T) {
+				createDesktopSessionFixture(t, desktopSessionFixture{
+					Name:    "alpha",
+					IP:      "127.0.0.1",
+					Pid:     999999,
+					State:   "exited",
+					Host:    "localhost",
+					Display: "1",
+				})
+			},
+			expectedResponse: cleanCommandResponse{
+				Success: true,
+				Results: []cleanCommandResult{
+					{
+						Success:     true,
+						SessionName: "alpha",
+					},
+				},
+			},
+			expectedExitCode: 0,
+			expectRemoved:    true,
+		},
+		{
+			name:        "not local",
+			sessionName: "beta",
+			setup: func(t *testing.T) {
+				createDesktopSessionFixture(t, desktopSessionFixture{
+					Name:    "beta",
+					IP:      "192.0.2.10",
+					Pid:     999999,
+					State:   "exited",
+					Host:    "remote-host",
+					Display: "2",
+				})
+			},
+			expectedResponse: cleanCommandResponse{
+				Success: false,
+				Results: []cleanCommandResult{
+					{
+						Success:     false,
+						SessionName: "beta",
+						Error:       "Desktop session 'beta' is not local.",
+						Reason:      "not_local",
+					},
+				},
+			},
+			expectedExitCode: 1,
+		},
+		{
+			name:        "active",
+			sessionName: "gamma",
+			setup: func(t *testing.T) {
+				proc := startTestProcess(t)
+				createDesktopSessionFixture(t, desktopSessionFixture{
+					Name:    "gamma",
+					IP:      "127.0.0.1",
+					Pid:     proc.Process.Pid,
+					State:   "active",
+					Host:    "localhost",
+					Display: "3",
+				})
+			},
+			expectedResponse: cleanCommandResponse{
+				Success: false,
+				Results: []cleanCommandResult{
+					{
+						Success:     false,
+						SessionName: "gamma",
+						Error:       "Desktop session 'gamma' is active.",
+						Reason:      "active",
+					},
+				},
+			},
+			expectedExitCode: 1,
+		},
+		{
+			name:        "not found treated as success",
+			sessionName: "delta",
+			setup:       func(t *testing.T) {},
+			expectedResponse: cleanCommandResponse{
+				Success: true,
+				Results: []cleanCommandResult{
+					{
+						Success:     true,
+						SessionName: "delta",
+					},
+				},
+			},
+			expectedExitCode: 0,
+		},
+		{
+			name:        "clean failed",
+			sessionName: "epsilon",
+			setup: func(t *testing.T) {
+				createDesktopSessionFixture(t, desktopSessionFixture{
+					Name:    "epsilon",
+					IP:      "127.0.0.1",
+					Pid:     999999,
+					State:   "exited",
+					Host:    "localhost",
+					Display: "4",
+				})
+				sessionsDir := filepath.Join(tmpDir, "local", "state", "flight", "desktop", "sessions")
+				if err := os.Chmod(sessionsDir, 0o500); err != nil {
+					t.Fatalf("failed to make sessions dir read-only: %v", err)
+				}
+				t.Cleanup(func() {
+					_ = os.Chmod(sessionsDir, 0o755)
+				})
+			},
+			expectedResponse: cleanCommandResponse{
+				Success: false,
+				Results: []cleanCommandResult{
+					{
+						Success:     false,
+						SessionName: "epsilon",
+						Error:       "Cleaning session 'epsilon' failed.",
+						Reason:      "clean_failed",
+					},
+				},
+			},
+			expectedExitCode: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetDesktopSessionState(t)
+			tt.setup(t)
+
+			output, err := runBinary([]string{"clean", "--format", "json", "--", tt.sessionName}, nil)
+			assertExitCode(t, tt.expectedExitCode, output, err)
+
+			var got cleanCommandResponse
+			if err := json.NewDecoder(bytes.NewReader(output)).Decode(&got); err != nil {
+				t.Fatalf("failed to decode JSON output: %v\noutput: %s", err, output)
+			}
+
+			if got.Success != tt.expectedResponse.Success {
+				t.Fatalf("expected success=%v, got %v", tt.expectedResponse.Success, got.Success)
+			}
+			if len(got.Results) != len(tt.expectedResponse.Results) {
+				t.Fatalf("expected %d results, got %d: %#v", len(tt.expectedResponse.Results), len(got.Results), got.Results)
+			}
+			for i, want := range tt.expectedResponse.Results {
+				gotResult := got.Results[i]
+				if gotResult != want {
+					t.Fatalf("expected result[%d]=%#v, got %#v", i, want, gotResult)
+				}
+			}
+
+			sessionDir := filepath.Join(tmpDir, "local", "state", "flight", "desktop", "sessions", tt.sessionName)
+			_, statErr := os.Stat(sessionDir)
+			if tt.expectRemoved && !os.IsNotExist(statErr) {
+				t.Fatalf("expected session dir %q to be removed, stat err=%v", sessionDir, statErr)
+			}
+		})
+	}
+}

--- a/flight-desktop/session_details.go
+++ b/flight-desktop/session_details.go
@@ -107,10 +107,14 @@ func connectionInfo(session *Session) {
 }
 
 func managementInfo(session *Session) {
+	instructions := "To view details or stop this session, you will need the Session Name:"
+	if session.SessionState() == Exited || session.SessionState() == Broken {
+		instructions = "To view details or clean this session, you will need the Session Name:"
+	}
 	out := lipgloss.JoinVertical(
 		lipgloss.Left,
 		cliui.Header.Render("Manage this session"),
-		cliui.Paragraph.PaddingBottom(0).Render("To view details or stop this session, you will need the Session Name:"),
+		cliui.Paragraph.PaddingBottom(0).Render(instructions),
 		cliui.Code.Margin(0, 0, 1, 1).Render(session.Name),
 		cliui.Paragraph.Render("(Tip: Run 'flight desktop --help' to see management commands)"),
 	)

--- a/flight-desktop/session_details.go
+++ b/flight-desktop/session_details.go
@@ -44,7 +44,7 @@ func sessionInfo(session *Session) {
 			dd.Render(session.Name),
 			dd.Render(session.SessionType),
 			dd.Render(session.Geometry),
-			dd.Render(string(session.SessionState())),
+			dd.Render(string(session.ComputedState())),
 			dd.Render(session.CreatedAt.Format(time.RFC822)),
 		),
 	)
@@ -108,7 +108,7 @@ func connectionInfo(session *Session) {
 
 func managementInfo(session *Session) {
 	instructions := "To view details or stop this session, you will need the Session Name:"
-	if session.SessionState() == Exited || session.SessionState() == Broken {
+	if session.ComputedState() == Exited || session.ComputedState() == Broken {
 		instructions = "To view details or clean this session, you will need the Session Name:"
 	}
 	out := lipgloss.JoinVertical(

--- a/flight-desktop/session_kill.go
+++ b/flight-desktop/session_kill.go
@@ -37,7 +37,7 @@ func killSessionCommand() *cli.Command {
 				}
 				return err
 			}
-			if !session.IsLocal() {
+			if session.ComputedState() == Remote {
 				return cli.Exit(fmt.Sprintf("Desktop session '%s' is not local.\n", session.Name), 1)
 			}
 			if session.State != Active {
@@ -79,16 +79,17 @@ func killSessionJSON(ctx context.Context, session *Session, loadErr error) error
 		}
 		return writeTerminationFailure(session.Name, loadErr.Error(), "terminate_failed")
 	}
-	if !session.IsLocal() {
+	switch session.ComputedState() {
+	case Remote:
 		return writeTerminationFailure(session.Name, fmt.Sprintf("Desktop session '%s' is not local.", session.Name), "not_local")
-	}
-	if session.State != Active {
+	case Active:
+		if err := session.Kill(ctx); err != nil {
+			return writeTerminationFailure(session.Name, fmt.Sprintf("Terminating session '%s' failed.", session.Name), "terminate_failed")
+		}
+		return writeTerminationSuccess(session.Name)
+	default:
 		return writeTerminationFailure(session.Name, fmt.Sprintf("Desktop session '%s' is not active.", session.Name), "not_active")
 	}
-	if err := session.Kill(ctx); err != nil {
-		return writeTerminationFailure(session.Name, fmt.Sprintf("Terminating session '%s' failed.", session.Name), "terminate_failed")
-	}
-	return writeTerminationSuccess(session.Name)
 }
 
 func writeTerminationSuccess(sessionName string) error {
@@ -130,7 +131,7 @@ func completeActiveSessionNames(ctx context.Context, cmd *cli.Command) {
 			return
 		}
 		for _, session := range sessions {
-			if session.SessionState() == Active {
+			if session.ComputedState() == Active {
 				fmt.Println(session.Name)
 			}
 		}

--- a/flight-desktop/session_list.go
+++ b/flight-desktop/session_list.go
@@ -52,7 +52,7 @@ func writeSessionsJSON(sessions []*Session) error {
 		output = append(output, listedSession{
 			Name:        session.Name,
 			DesktopType: session.SessionType,
-			State:       session.SessionState(),
+			State:       session.ComputedState(),
 			Host:        session.Metadata.Host,
 			CreatedAt:   session.CreatedAt.Format(time.RFC3339),
 		})
@@ -111,7 +111,7 @@ func sessionsTable(sessions []*Session) error {
 			s.SessionType,
 			connectionString,
 			s.Password,
-			string(s.SessionState()),
+			string(s.ComputedState()),
 		)
 	}
 	_, err := lipgloss.Println(t)

--- a/flight-desktop/testdata/golden/clean-help.golden
+++ b/flight-desktop/testdata/golden/clean-help.golden
@@ -21,7 +21,8 @@ DESCRIPTION:
    that are marked as 'exited' or 'broken' will be removed.
 
 OPTIONS:
-   --help, -h  show help
+   --format FORMAT  use specified FORMAT for the output (pretty, json). (default: "pretty")
+   --help, -h       show help
 
 GLOBAL OPTIONS:
    --log-level LEVEL  set the log LEVEL (debug, info, warn, error, fatal). Default: warn

--- a/flight-desktop/testdata/golden/clean-help.golden
+++ b/flight-desktop/testdata/golden/clean-help.golden
@@ -1,5 +1,5 @@
 NAME:
-   flight desktop clean - Clean up one or more exited desktop sessions
+   flight desktop clean - Clean up one or more exited or broken desktop sessions
 
 USAGE:
    flight desktop clean [options] [<id>...] 

--- a/flight-desktop/testdata/golden/help.golden
+++ b/flight-desktop/testdata/golden/help.golden
@@ -22,7 +22,7 @@ COMMANDS:
      show   Show information about a desktop session
      logs   Show desktop session logs
      kill   Terminate an interactive desktop session
-     clean  Clean up one or more exited desktop sessions
+     clean  Clean up one or more exited or broken desktop sessions
 
 GLOBAL OPTIONS:
    --log-level LEVEL  set the log LEVEL (debug, info, warn, error, fatal). Default: warn

--- a/flight-web-suite/desktop/clean.go
+++ b/flight-web-suite/desktop/clean.go
@@ -1,0 +1,51 @@
+package desktop
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/concertim/flight-user-suite/flight/configenv"
+)
+
+type cleanResponse struct {
+	Success     bool   `json:"success"`
+	SessionName string `json:"session_name"`
+	Error       string `json:"error"`
+	Reason      string `json:"reason"`
+}
+
+type cleanCommandDocument struct {
+	Success bool            `json:"success"`
+	Results []cleanResponse `json:"results"`
+}
+
+func CleanCommand(ctx context.Context, env configenv.Env, username, sessionName string) (cleanResponse, error) {
+	cmd, err := buildDesktopCommand(ctx, env, username, "clean", "--format", "json", "--", sessionName)
+	if err != nil {
+		return cleanResponse{}, err
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	var response cleanCommandDocument
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &response); decodeErr == nil {
+		if len(response.Results) == 1 {
+			return response.Results[0], nil
+		}
+		return cleanResponse{}, fmt.Errorf("decoding desktop clean response: expected 1 result, got %d", len(response.Results))
+	}
+
+	if runErr != nil {
+		if stderr.Len() != 0 {
+			return cleanResponse{}, fmt.Errorf("cleaning desktop session: %s", stderr.String())
+		}
+		return cleanResponse{}, fmt.Errorf("cleaning desktop session: %w", runErr)
+	}
+	return cleanResponse{}, fmt.Errorf("decoding desktop clean response: %s", stdout.String())
+}

--- a/flight-web-suite/desktop_sessions.go
+++ b/flight-web-suite/desktop_sessions.go
@@ -11,14 +11,16 @@ import (
 )
 
 type desktopSessionCard struct {
-	Name          string
-	DesktopType   string
-	State         string
-	Host          string
-	StartTimeText string
-	ActionLabel   string
-	ActionTitle   string
-	ActionEnabled bool
+	Name                 string
+	DesktopType          string
+	State                string
+	Host                 string
+	StartTimeText        string
+	ActionLabel          string
+	ActionTitle          string
+	ActionEnabled        bool
+	ActionPath           string
+	ActionMethodOverride string
 }
 
 func indexDesktopSessionsHandler(c *echo.Context) error {
@@ -74,31 +76,68 @@ func destroyDesktopSessionHandler(c *echo.Context) error {
 	return c.Redirect(http.StatusSeeOther, "/desktop")
 }
 
+func cleanDesktopSessionHandler(c *echo.Context) error {
+	if !IsLoggedIn(c) {
+		return c.Redirect(http.StatusSeeOther, "/sessions")
+	}
+	if err := requireDesktopToolEnabled(); err != nil {
+		return err
+	}
+
+	response, err := desktop.CleanCommand(c.Request().Context(), env, CurrentUserName(c), c.Param("sessionName"))
+	if err != nil {
+		return err
+	}
+
+	sess, err := GetSession(c)
+	if err != nil {
+		return err
+	}
+	if response.Success {
+		sess.AddFlash(fmt.Sprintf("Desktop session '%s' removed.", response.SessionName), "notice")
+	} else {
+		sess.AddFlash(fmt.Sprintf("Failed to remove desktop session '%s': %s", response.SessionName, response.Error), "alert")
+	}
+	SaveSession(c, sess)
+	return c.Redirect(http.StatusSeeOther, "/desktop")
+}
+
 func buildDesktopSessionCards(sessions []*desktop.Session) []desktopSessionCard {
 	cards := make([]desktopSessionCard, 0, len(sessions))
 	for _, session := range sessions {
-		actionLabel := "Clean"
-		actionTitle := "Cleaning desktop sessions is not yet implemented."
+		actionLabel := ""
+		actionTitle := ""
 		actionEnabled := false
+		actionPath := ""
+		actionMethodOverride := ""
 		switch session.State {
 		case "active":
 			actionLabel = "Terminate"
 			actionTitle = ""
 			actionEnabled = true
+			actionPath = fmt.Sprintf("/desktop/%s", session.Name)
+			actionMethodOverride = "DELETE"
+		case "broken", "exited":
+			actionLabel = "Remove"
+			actionTitle = ""
+			actionEnabled = true
+			actionPath = fmt.Sprintf("/desktop/%s/clean", session.Name)
 		case "remote":
 			actionLabel = "Terminate"
 			actionTitle = "Termination of remote sessions is not yet implemented."
 		}
 
 		cards = append(cards, desktopSessionCard{
-			Name:          session.Name,
-			DesktopType:   session.DesktopType,
-			State:         session.State,
-			Host:          session.Host,
-			StartTimeText: session.CreatedAt.Format("Mon 2 Jan 2006 15:04"),
-			ActionLabel:   actionLabel,
-			ActionTitle:   actionTitle,
-			ActionEnabled: actionEnabled,
+			Name:                 session.Name,
+			DesktopType:          session.DesktopType,
+			State:                session.State,
+			Host:                 session.Host,
+			StartTimeText:        session.CreatedAt.Format("Mon 2 Jan 2006 15:04"),
+			ActionLabel:          actionLabel,
+			ActionTitle:          actionTitle,
+			ActionEnabled:        actionEnabled,
+			ActionPath:           actionPath,
+			ActionMethodOverride: actionMethodOverride,
 		})
 	}
 	return cards

--- a/flight-web-suite/desktop_sessions_functional_test.go
+++ b/flight-web-suite/desktop_sessions_functional_test.go
@@ -72,10 +72,9 @@ JSON
 	testutil.AssertSelection(t, body, `[data-testid="desktop-session-card--beta"] h2`,
 		testutil.HasText("beta"),
 	)
+	testutil.AssertSelection(t, body, `form[action="/desktop/beta/clean"] [data-testid="desktop-session-action-button--beta"]`)
 	testutil.AssertSelection(t, body, `[data-testid="desktop-session-action-button--beta"]`,
-		testutil.HasText("Clean"),
-		testutil.HasAttr("disabled", ""),
-		testutil.HasAttr("title", "Cleaning desktop sessions is not yet implemented."),
+		testutil.HasText("Remove"),
 	)
 }
 
@@ -138,6 +137,27 @@ echo '[]'
 	}
 }
 
+func TestCleanDesktopSessionRedirectsForAnonymous(t *testing.T) {
+	resp, _ := testutil.RenderPage(t, newApp(), http.MethodPost, "/desktop/alpha/clean", nil, http.StatusSeeOther)
+
+	if resp.Header.Get("location") != "/sessions" {
+		t.Errorf("expected desktop clean to redirect to '/sessions' for anonymous users")
+	}
+}
+
+func TestCleanDesktopSessionReturnsServiceUnavailableWhenToolDisabled(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o644, `#!/bin/sh
+echo '[]'
+`))
+
+	_, body := testutil.RenderPage(t, newApp(), http.MethodPost, "/desktop/alpha/clean", nil, http.StatusServiceUnavailable, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	if want := "Flight Desktop is not enabled"; !strings.Contains(body, want) {
+		t.Fatalf("expected body to contain %q, got %q", want, body)
+	}
+}
+
 func TestDestroyDesktopSessionInvokesKillWithJSONFormat(t *testing.T) {
 	currentUser := currentUserForTest(t)
 	argsFile := filepath.Join(t.TempDir(), "desktop-args.txt")
@@ -159,6 +179,35 @@ JSON
 	}
 	if got := strings.TrimSpace(string(data)); got != "kill\n--format\njson\n--\nalpha" {
 		t.Fatalf("expected kill command args, got %q", got)
+	}
+}
+
+func TestCleanDesktopSessionInvokesCleanWithJSONFormat(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	argsFile := filepath.Join(t.TempDir(), "desktop-args.txt")
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+printf '%s\n' "$@" > "`+argsFile+`"
+cat <<'JSON'
+{
+  "success": true,
+  "results": [
+    {
+      "success": true,
+      "session_name": "alpha"
+    }
+  ]
+}
+JSON
+`))
+
+	testutil.RenderPage(t, newApp(), http.MethodPost, "/desktop/alpha/clean", nil, http.StatusSeeOther, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("failed to read command args fixture: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "clean\n--format\njson\n--\nalpha" {
+		t.Fatalf("expected clean command args, got %q", got)
 	}
 }
 

--- a/flight-web-suite/desktop_sessions_integration_test.go
+++ b/flight-web-suite/desktop_sessions_integration_test.go
@@ -77,3 +77,78 @@ exit 1
 		testutil.HasText("Failed to terminate desktop session 'alpha': Desktop session 'alpha' is not active."),
 	)
 }
+
+func TestCleanDesktopSessionSuccessAddsFlashAndRedirects(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setAuthenticatorPathForTest(t, filepath.Join("testdata", "authenticator_success.sh"))
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+if [ "$1" = "list" ]; then
+  echo '[]'
+  exit 0
+fi
+cat <<'JSON'
+{
+  "success": true,
+  "results": [
+    {
+      "success": true,
+      "session_name": "alpha"
+    }
+  ]
+}
+JSON
+`))
+
+	srv, client := testutil.SetupIntegrationServer(t, newApp())
+	client.PostForm(srv.URL+"/sessions", url.Values{
+		"username": {currentUser.Username},
+		"password": {"fakepassword"},
+	})
+	client.FollowRedirect()
+	client.PostForm(srv.URL+"/desktop/alpha/clean", url.Values{})
+
+	client.AssertRedirect(t, http.StatusSeeOther, "/desktop")
+	_, body := client.FollowRedirect()
+	testutil.AssertSelection(t, body, `div.flash.notice`,
+		testutil.HasText("Desktop session 'alpha' removed."),
+	)
+}
+
+func TestCleanDesktopSessionFailureAddsFlashAndRedirects(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setAuthenticatorPathForTest(t, filepath.Join("testdata", "authenticator_success.sh"))
+	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+if [ "$1" = "list" ]; then
+  echo '[]'
+  exit 0
+fi
+cat <<'JSON'
+{
+  "success": false,
+  "results": [
+    {
+      "success": false,
+      "session_name": "alpha",
+      "error": "Desktop session 'alpha' is active.",
+      "reason": "active"
+    }
+  ]
+}
+JSON
+exit 1
+`))
+
+	srv, client := testutil.SetupIntegrationServer(t, newApp())
+	client.PostForm(srv.URL+"/sessions", url.Values{
+		"username": {currentUser.Username},
+		"password": {"fakepassword"},
+	})
+	client.FollowRedirect()
+	client.PostForm(srv.URL+"/desktop/alpha/clean", url.Values{})
+
+	client.AssertRedirect(t, http.StatusSeeOther, "/desktop")
+	_, body := client.FollowRedirect()
+	testutil.AssertSelection(t, body, `div.flash.alert`,
+		testutil.HasText("Failed to remove desktop session 'alpha': Desktop session 'alpha' is active."),
+	)
+}

--- a/flight-web-suite/main.go
+++ b/flight-web-suite/main.go
@@ -112,6 +112,7 @@ func newApp() *echo.Echo {
 	e.GET("/desktop", indexDesktopSessionsHandler)
 	e.GET("/desktop/new", newDesktopSessionHandler)
 	e.POST("/desktop", createDesktopSessionHandler)
+	e.POST("/desktop/:sessionName/clean", cleanDesktopSessionHandler)
 	e.DELETE("/desktop/:sessionName", destroyDesktopSessionHandler)
 	e.GET("/sessions", newSessionHandler)
 	e.POST("/sessions", createSessionHandler)

--- a/flight-web-suite/views/pages/desktop/index.gohtml
+++ b/flight-web-suite/views/pages/desktop/index.gohtml
@@ -17,8 +17,10 @@
                 <summary class="cursor-pointer list-none" aria-label="Session actions">☰</summary>
                 <div class="absolute top-6 right-0 z-10 min-w-32 border border-alces-blue-light bg-white p-2 shadow-md">
                     {{if .ActionEnabled}}
-                    <form action="/desktop/{{ .Name }}" method="post">
-                        <input type="hidden" name="_method" value="DELETE">
+                    <form action="{{ .ActionPath }}" method="post">
+                        {{if .ActionMethodOverride}}
+                        <input type="hidden" name="_method" value="{{ .ActionMethodOverride }}">
+                        {{end}}
                         <button class="w-full cursor-pointer text-left" type="submit"
                             data-testid="desktop-session-action-button--{{ .Name }}">{{ .ActionLabel }}</button>
                     </form>


### PR DESCRIPTION
This PR is based on the branch under review in #137.  It makes renames the "Clean" button to "Remove" and makes it functional.

<img width="917" height="529" alt="image" src="https://github.com/user-attachments/assets/2312beb5-2006-4bc1-9465-5a33b27e9cd9" />


The pattern for implementing this is similar to the pattern for [terminating sessions](#132). I'll not describe it again here.

Some issues around cleaning stale desktop sessions have been fixed.

* `desktop clean` now cleans all broken sessions (or at least all that appear in `list` output).
* fixed its `--help` output to be consistent with cleaning broken sessions.
* fixed its shell completions to include both exited and broken sessions.

Fixed some issues around the detection of broken sessions.

* If a session's metadata doesn't contain an IP it is now broken, not remote.
* Update code to use `session.ComputeState()` in preference to `session.State`/`session.isLocal()` and documented this.
* Primary connection string now correctly handles broken sessions by returning an empty string.