### PR TITLE
Improved template rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 flight-user-suite*.tar.gz
 flight-web-suite/tmp/*
 flight-web-suite/static/*
+flight-web-suite/node_modules
 flight-web-suite/bin/tailwind/tailwindcss
 *.DS_Store*

--- a/flight-web-suite/.air.toml
+++ b/flight-web-suite/.air.toml
@@ -19,14 +19,17 @@ tmp_dir = "tmp"
   full_bin = ""
   ignore_dangerous_root_dir = false
   include_dir = []
-  include_ext = ["go", "tpl", "tmpl", "gohtml", "css"]
+  include_ext = ["go", "tpl", "tmpl", "gohtml", "css", "js"]
   include_file = []
   kill_delay = "0s"
   log = "build-errors.log"
   poll = false
   poll_interval = 0
   post_cmd = []
-  pre_cmd = ["./bin/tailwind/tailwindcss --config ./tailwind.config.js -i ./assets/styles/application.css -o ./static/styles.css"]
+  pre_cmd = [
+      "./bin/tailwind/tailwindcss --config ./tailwind.config.js -i ./assets/styles/application.css -o ./static/styles.css",
+      "./node_modules/.bin/esbuild assets/javascript/application.js --bundle --outfile=static/js/application.js --sourcemap"
+  ]
   rerun = false
   rerun_delay = 500
   send_interrupt = false

--- a/flight-web-suite/Makefile
+++ b/flight-web-suite/Makefile
@@ -8,20 +8,21 @@ FLIGHT_STATE_ROOT := tmp
 WEB_ROOT := $(FLIGHT_ROOT)/var/web-suite
 TAILWIND := ./bin/tailwind/tailwindcss
 GOTESTSUM := $(shell type -p gotestsum)
+ESBUILD := ./node_modules/.bin/esbuild
 
 VERSION := $(shell git describe --tags --dirty --always)
 COMMIT := $(shell git rev-parse HEAD)
 DATE := $(shell date --rfc-3339=seconds)
 LD_FLAGS := -ldflags="-X 'main.version=$(VERSION)' -X 'main.commit=$(COMMIT)' -X 'main.date=$(DATE)'"
 
-.PHONY: all $(EXE) assets build-css clean distclean dev help run test
+.PHONY: all $(EXE) assets build-css build-javascript clean distclean dev help run test
 
 all: $(EXE) assets
 
 $(EXE):
 	CGO_ENABLED=0 go build -v $(LD_FLAGS) -o $(EXE)
 
-assets: build-css
+assets: build-css build-javascript
 	mkdir -p $(WEB_ROOT)
 	rsync -rlptgo --exclude .gitkeep $(ASSET_DIRS) $(WEB_ROOT)/
 	rsync -rlptgo --exclude .gitkeep $(OPT) $(DIST)/
@@ -35,7 +36,17 @@ build-css: $(TAILWIND)
 		-i ./assets/styles/application.css \
 		-o ./static/styles.css
 
-dev: $(TAILWIND)
+$(ESBUILD):
+	npm install
+
+build-javascript: $(ESBUILD)
+	$(ESBUILD) \
+		assets/javascript/application.js \
+		--bundle \
+		--outfile=static/js/application.js \
+		--minify
+
+dev: $(TAILWIND) $(ESBUILD)
 	FLIGHT_ROOT=$(OPT)/flight FLIGHT_STATE_ROOT=$(FLIGHT_STATE_ROOT) air
 
 run: all

--- a/flight-web-suite/assets/javascript/application.js
+++ b/flight-web-suite/assets/javascript/application.js
@@ -1,0 +1,1 @@
+console.log("Hello, Flight Web Suite")

--- a/flight-web-suite/desktop_launch.go
+++ b/flight-web-suite/desktop_launch.go
@@ -153,7 +153,7 @@ func renderDesktopLaunchPage(c *echo.Context, status int, desktopTypes []*deskto
 		"GeometryOptions": desktopGeometryOptions,
 		"Form":            form,
 	}
-	return c.Render(status, "desktop/new", AddCommonData(c, data))
+	return c.Render(status, "desktop/new", data)
 }
 
 func defaultDesktopType(desktopTypes []*desktop.Type) string {

--- a/flight-web-suite/desktop_sessions.go
+++ b/flight-web-suite/desktop_sessions.go
@@ -45,7 +45,7 @@ func indexDesktopSessionsHandler(c *echo.Context) error {
 		"Summary":         desktopSessionsSummary(sessions),
 		"DesktopSessions": buildDesktopSessionCards(sessions),
 	}
-	return c.Render(http.StatusOK, "desktop/index", AddCommonData(c, data))
+	return c.Render(http.StatusOK, "desktop/index", data)
 }
 
 func destroyDesktopSessionHandler(c *echo.Context) error {

--- a/flight-web-suite/main.go
+++ b/flight-web-suite/main.go
@@ -94,9 +94,11 @@ func newApp() *echo.Echo {
 	e.Use(middleware.RequestLogger())
 	e.Use(NewSessionMiddleware())
 
-	t := template.Must(template.ParseGlob(getDirectory("views") + "/*.gohtml"))
-	t = template.Must(t.ParseGlob(getDirectory("views") + "/*/*.gohtml"))
-	e.Renderer = &echo.TemplateRenderer{Template: t}
+	t := template.Must(template.ParseGlob(getDirectory("views") + "/layouts/*.gohtml"))
+	// TODO: Move partials from layouts to partials and uncomment this line.
+	// t = template.Must(t.ParseGlob(getDirectory("views") + "/partials/*.gohtml"))
+
+	e.Renderer = &TemplateRenderer{Template: t}
 
 	e.Static("/assets", getDirectory("assets"))
 	e.Static("/static", getDirectory("static"))
@@ -105,7 +107,7 @@ func newApp() *echo.Echo {
 		if err != nil {
 			e.Logger.Error("Error when calling indexData", "error", err)
 		}
-		return c.Render(http.StatusOK, "home", AddCommonData(c, data))
+		return c.Render(http.StatusOK, "home", data)
 	})
 	e.GET("/desktop", indexDesktopSessionsHandler)
 	e.GET("/desktop/new", newDesktopSessionHandler)

--- a/flight-web-suite/package-lock.json
+++ b/flight-web-suite/package-lock.json
@@ -1,0 +1,469 @@
+{
+  "name": "flight-web-suite",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "esbuild": "0.28.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    }
+  }
+}

--- a/flight-web-suite/package.json
+++ b/flight-web-suite/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "esbuild": "0.28.0"
+  }
+}

--- a/flight-web-suite/renderer.go
+++ b/flight-web-suite/renderer.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"io"
+
+	"github.com/labstack/echo/v5"
+)
+
+// TemplateRenderer is a custom renderer that supports jinja2-inspired template
+// inheritance and custom layouts.
+//
+//   - Templates are split into "layouts", "partials" and "pages".
+//   - On startup, all layout and partial templates should be parsed. They must
+//     not `define` conflicting sections.
+//   - Layouts define a "content" section that pages plug.
+//   - All pages define a "content" that is plugged into the layout.  These
+//     necessarily conflict, so only a single page can be added  to a template set.
+//   - On each request, the base set of templates is cloned and the single page
+//     being rendered is added to the set.
+//   - If the data argument contains a "layout" entry that layout is used to
+//     render the template. The "application" layout is used by default.
+type TemplateRenderer struct {
+	// The base set of templates that can be parsed on startup.
+	Template *template.Template
+}
+
+// Render implements the echo.Renderer interface.
+func (tr *TemplateRenderer) Render(c *echo.Context, w io.Writer, name string, data any) error {
+	clone := template.Must(tr.Template.Clone())
+	pageTemplate := fmt.Sprintf("%s/pages/%s.gohtml", getDirectory("views"), name)
+	withPage, err := clone.ParseFiles(pageTemplate)
+	if err != nil {
+		return err
+	}
+	if data == nil {
+		data = make(map[string]any)
+	}
+	switch data := data.(type) {
+	case map[string]any:
+		layout := "application"
+		if l, ok := data["layout"]; ok {
+			switch l := l.(type) {
+			case string:
+				layout = l
+			default:
+				c.Logger().Warn("invalid layout type", "type", fmt.Sprintf("%T", l))
+			}
+		}
+		return withPage.ExecuteTemplate(w, fmt.Sprintf("layouts.%s", layout), AddCommonData(c, data))
+	default:
+		return fmt.Errorf("unsupported data format got %T want map[string]any", data)
+	}
+}

--- a/flight-web-suite/sessions.go
+++ b/flight-web-suite/sessions.go
@@ -14,7 +14,7 @@ func newSessionHandler(c *echo.Context) error {
 	if IsLoggedIn(c) {
 		return c.Redirect(http.StatusSeeOther, "/")
 	}
-	return c.Render(http.StatusOK, "sessions/new", AddCommonData(c, nil))
+	return c.Render(http.StatusOK, "sessions/new", nil)
 }
 
 func createSessionHandler(c *echo.Context) error {
@@ -28,7 +28,7 @@ func createSessionHandler(c *echo.Context) error {
 	if username == "" || password == "" {
 		sess.AddFlash("Username and/or password not provided", "alert")
 		SaveSession(c, sess)
-		return c.Render(http.StatusOK, "sessions/new", AddCommonData(c, nil))
+		return c.Render(http.StatusOK, "sessions/new", nil)
 	}
 	ok, err := authenticate(c.Request().Context(), username, password)
 	if err != nil {
@@ -44,7 +44,7 @@ func createSessionHandler(c *echo.Context) error {
 		sess.AddFlash("Invalid username or password", "alert")
 		SaveSession(c, sess)
 		data := map[string]any{"username": username}
-		return c.Render(http.StatusOK, "sessions/new", AddCommonData(c, data))
+		return c.Render(http.StatusOK, "sessions/new", data)
 	}
 }
 

--- a/flight-web-suite/views/layouts/application.gohtml
+++ b/flight-web-suite/views/layouts/application.gohtml
@@ -8,6 +8,8 @@
     <link rel="stylesheet" href="/static/styles.css">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <script defer src="/static/js/application.js"></script>
 </head>
 
 <body class="flex flex-col h-screen m-0 p-0 font-sans">

--- a/flight-web-suite/views/layouts/application.gohtml
+++ b/flight-web-suite/views/layouts/application.gohtml
@@ -1,4 +1,4 @@
-{{define "layouts.application.start"}}
+{{ define "layouts.application" }}
 <!DOCTYPE html>
 <html lang="en">
 
@@ -31,13 +31,10 @@
     {{ template "flashes" .flashes }}
     <div class="grow overflow-y-auto px-[15%] bg-linear-to-b from-alces-blue-light to-white">
         <div class="bg-white p-4 text-center h-min min-h-full">
-
-            {{end}}
-            {{define "layouts.application.end"}}
-
+            {{ block "content" . }}{{ end }}
         </div>
     </div>
 </body>
 
 </html>
-{{end}}
+{{ end }}

--- a/flight-web-suite/views/pages/desktop/index.gohtml
+++ b/flight-web-suite/views/pages/desktop/index.gohtml
@@ -1,6 +1,4 @@
-{{define "desktop/index"}}
-{{template "layouts.application.start" . }}
-
+{{ define "content" }}
 <div class="mt-20 mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
     <div class="flex-grow">
         <h1 class="mb-2">Desktop Sessions</h1>
@@ -45,6 +43,4 @@
     </div>
     {{end}}
 </div>
-
-{{template "layouts.application.end" . }}
 {{end}}

--- a/flight-web-suite/views/pages/desktop/new.gohtml
+++ b/flight-web-suite/views/pages/desktop/new.gohtml
@@ -1,6 +1,4 @@
-{{define "desktop/new"}}
-{{template "layouts.application.start" . }}
-
+{{ define "content" }}
 <div class="mx-auto mt-6 max-w-5xl text-left">
     <a href="/desktop" class="inline-flex items-center gap-2 text-sm text-slate-500"
         data-testid="desktop-launch-back-link">← Back to desktops</a>
@@ -93,6 +91,4 @@
         {{end}}
     </div>
 </div>
-
-{{template "layouts.application.end" . }}
 {{end}}

--- a/flight-web-suite/views/pages/home.gohtml
+++ b/flight-web-suite/views/pages/home.gohtml
@@ -1,6 +1,4 @@
-{{define "home"}}
-{{template "layouts.application.start" . }}
-
+{{ define "content" }}
 <h1 class="mt-20 mb-15">
     Welcome to the <span class="text-alces-blue">{{ .EnvName }}</span> compute environment.
 </h1>
@@ -37,6 +35,4 @@
         cluster to access Flight Web Suite functionality.
     </p>
 {{ end }}
-
-{{template "layouts.application.end" . }}
-{{end}}
+{{ end }}

--- a/flight-web-suite/views/pages/sessions/new.gohtml
+++ b/flight-web-suite/views/pages/sessions/new.gohtml
@@ -1,5 +1,4 @@
-{{define "sessions/new"}}
-{{template "layouts.application.start" . }}
+{{ define "content" }}
 <h1 class="mt-20 mb-15">
     Log in to <span class="text-alces-blue">OpenFlight</span>
 </h1>
@@ -22,6 +21,4 @@
         <input class="submit-button" type="submit" value="Log in" />
     </div>
 </form>
-
-{{template "layouts.application.end" . }}
 {{end}}


### PR DESCRIPTION
This PR improves template rendering and adds a JS pipeline.  The motivation for this is to support connections to desktop sessions, which requires the NoVNC javascript library and for a different page layout for the session page.

To add JavaScript to the build, write a new JS file in `assets/javascripts` and `import` it in `assets/javascripts/application.js`.

Template rendering has been reworked to add jinja2-inspired template inheritance and custom layouts.

* Templates have split into "layouts", "partials" and "pages".
* On startup, all layout and partial templates are parsed.
* Layouts define the layout for the page along with a "content" block that pages redefine.
* All pages define "content" that is plugged into the layout.  As all pages define this, they necessarily conflict, so only a single page can be added to the template set when rendering.
* On each request, the base set of templates is cloned and the single page being rendered is added. This ensures when the layout is rendered, there is a single redefinition of "content" that is used in the layout.
* If the `data` argument contains a "layout" entry that layout is used to render the template. The "application" layout is used by default.