### PR TITLE
Web suite can connect to desktop sessions

### DIFF
--- a/flight-desktop/config.go
+++ b/flight-desktop/config.go
@@ -17,6 +17,7 @@ type desktopConfig struct {
 	Dependencies  []dependency        `yaml:"dependencies"`
 	EnvWhitelist  []string            `yaml:"environment_whitelist"`
 	VncPasswd     string              `yaml:"vncpasswd"`
+	WebSockify    string              `yaml:"websockify"`
 }
 
 type nameGeneratorConfig struct {

--- a/flight-desktop/opt/flight/etc/desktop.yml
+++ b/flight-desktop/opt/flight/etc/desktop.yml
@@ -3,8 +3,9 @@ name_generator:
   # Either "absurd" or "meaningless". Default "absurd".
   strategy: "absurd"
 
-# NOTE: Keep this in sync with the dependencies entry below.
+# NOTE: Keep these in sync with the dependencies entry below.
 vncpasswd: "/usr/bin/vncpasswd"
+websockify: "/usr/bin/websockify"
 
 dependencies:
   - type: exe
@@ -31,6 +32,13 @@ dependencies:
     description: "Perl"
     paths:
       - "perl"
+
+  - type: exe
+    description: "Websockify"
+    optional: true
+    failure_message: "Accessing desktop sessions via Flight Web Suite will not be available"
+    paths:
+      - "/usr/bin/websockify"
 
 # Everything not included in this list is removed from the environment when
 # launching a new session.

--- a/flight-desktop/session.go
+++ b/flight-desktop/session.go
@@ -34,15 +34,16 @@ var (
 )
 
 type Session struct {
-	Name         string
-	SessionType  string          `yaml:"session_type"`
-	Password     string          `yaml:"password"`
-	IP           string          `yaml:"ip"`
-	State        sessionState    `yaml:"state"`
-	Geometry     string          `yaml:"geometry"`
-	CreatedAt    time.Time       `yaml:"created_at"`
-	Metadata     sessionMetadata `yaml:"metadata"`
-	WebsocketPid int             `yaml:"websocket_pid"`
+	Name          string
+	SessionType   string          `yaml:"session_type"`
+	Password      string          `yaml:"password"`
+	IP            string          `yaml:"ip"`
+	State         sessionState    `yaml:"state"`
+	Geometry      string          `yaml:"geometry"`
+	CreatedAt     time.Time       `yaml:"created_at"`
+	Metadata      sessionMetadata `yaml:"metadata"`
+	WebsocketPid  int             `yaml:"websocket_pid"`
+	WebsocketPort int             `yaml:"websocket_port"`
 }
 
 func loadAllSessions() ([]*Session, error) {
@@ -422,10 +423,23 @@ func (s *Session) startCleaner(ctx context.Context) error {
 	return nil
 }
 
-func (s *Session) startWebsockify(ctx context.Context) error {
+func (s *Session) GetWebsocketPort() int {
+	if s.WebsocketPort != 0 {
+		return s.WebsocketPort
+	}
+	port := s.Port()
+	if port == -1 {
+		return -1
+	}
 	// TODO: Pick different port if its already taken.
+	websockifyPort := 3000 + s.Port()
+	return websockifyPort
+}
+
+func (s *Session) startWebsockify(ctx context.Context) error {
+	websockifyPort := s.GetWebsocketPort()
 	args := []string{
-		fmt.Sprintf("0.0.0.0:%d", 3000+s.Port()),
+		fmt.Sprintf("0.0.0.0:%d", websockifyPort),
 		fmt.Sprintf("127.0.0.1:%d", s.Port()),
 	}
 	cmd := exec.CommandContext(ctx, config.WebSockify, args...)
@@ -440,6 +454,7 @@ func (s *Session) startWebsockify(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("starting websockify: %w", err)
 	}
+	s.WebsocketPort = websockifyPort
 	s.WebsocketPid = cmd.Process.Pid
 
 	return nil

--- a/flight-desktop/session.go
+++ b/flight-desktop/session.go
@@ -34,14 +34,15 @@ var (
 )
 
 type Session struct {
-	Name        string
-	SessionType string          `yaml:"session_type"`
-	Password    string          `yaml:"password"`
-	IP          string          `yaml:"ip"`
-	State       sessionState    `yaml:"state"`
-	Geometry    string          `yaml:"geometry"`
-	CreatedAt   time.Time       `yaml:"created_at"`
-	Metadata    sessionMetadata `yaml:"metadata"`
+	Name         string
+	SessionType  string          `yaml:"session_type"`
+	Password     string          `yaml:"password"`
+	IP           string          `yaml:"ip"`
+	State        sessionState    `yaml:"state"`
+	Geometry     string          `yaml:"geometry"`
+	CreatedAt    time.Time       `yaml:"created_at"`
+	Metadata     sessionMetadata `yaml:"metadata"`
+	WebsocketPid int             `yaml:"websocket_pid"`
 }
 
 func loadAllSessions() ([]*Session, error) {
@@ -120,6 +121,12 @@ func (s *Session) Start(ctx context.Context) error {
 	if err := s.startVNC(ctx, xdg.Home); err != nil {
 		s.cleanup()
 		return fmt.Errorf("staring VNC server: %w", err)
+	}
+	if err := s.startWebsockify(ctx); err != nil {
+		// Don't return an error here, as we still want to save the session and
+		// recovering from this error is possible by manually running the clean
+		// command.
+		log.Debug("Failed to start websockify process", "err", err)
 	}
 	if err := s.startCleaner(ctx); err != nil {
 		// Don't return an error here, as we still want to save the session and
@@ -401,7 +408,7 @@ func (s *Session) startCleaner(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, libexecPath("cleaner"))
 	cmd.Env = []string{
 		fmt.Sprintf("SESSION_VNC_PID=%s", pid),
-		"SESSION_PIDS=\"\"",
+		fmt.Sprintf("SESSION_PIDS=%d", s.WebsocketPid),
 		fmt.Sprintf("SESSION_DIR=%s", s.sessionDir()),
 	}
 	if os.Getenv("FLIGHT_DESKTOP_DEBUG") != "" {
@@ -412,6 +419,29 @@ func (s *Session) startCleaner(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("starting cleaner: %w", err)
 	}
+	return nil
+}
+
+func (s *Session) startWebsockify(ctx context.Context) error {
+	// TODO: Pick different port if its already taken.
+	args := []string{
+		fmt.Sprintf("0.0.0.0:%d", 3000+s.Port()),
+		fmt.Sprintf("127.0.0.1:%d", s.Port()),
+	}
+	cmd := exec.CommandContext(ctx, config.WebSockify, args...)
+	log.Debug("starting websockify", "path", config.WebSockify, "args", cmd.Args)
+	logFile, err := os.Create(filepath.Join(s.sessionDir(), "websocket.log"))
+	if err != nil {
+		return fmt.Errorf("starting websockify: %w", err)
+	}
+	cmd.Stdout = logFile
+	cmd.Dir = "/"
+	err = cmd.Start()
+	if err != nil {
+		return fmt.Errorf("starting websockify: %w", err)
+	}
+	s.WebsocketPid = cmd.Process.Pid
+
 	return nil
 }
 

--- a/flight-desktop/session_show.go
+++ b/flight-desktop/session_show.go
@@ -48,24 +48,26 @@ func showSessionCommand() *cli.Command {
 }
 
 type shownSession struct {
-	Name        string       `json:"name"`
-	DesktopType string       `json:"desktop_type"`
-	State       sessionState `json:"state"`
-	Host        string       `json:"host"`
-	Port        int          `json:"port"`
-	Password    string       `json:"password"`
-	CreatedAt   string       `json:"created_at"`
+	Name          string       `json:"name"`
+	DesktopType   string       `json:"desktop_type"`
+	State         sessionState `json:"state"`
+	Host          string       `json:"host"`
+	Port          int          `json:"port"`
+	WebsocketPort int          `json:"websocket_port"`
+	Password      string       `json:"password"`
+	CreatedAt     string       `json:"created_at"`
 }
 
 func writeSessionJSON(session *Session) error {
 	shownSession := shownSession{
-		Name:        session.Name,
-		DesktopType: session.SessionType,
-		State:       session.ComputedState(),
-		Host:        session.Metadata.Host,
-		Password:    session.Password,
-		Port:        session.Port(),
-		CreatedAt:   session.CreatedAt.Format(time.RFC3339),
+		Name:          session.Name,
+		DesktopType:   session.SessionType,
+		State:         session.ComputedState(),
+		Host:          session.Metadata.Host,
+		Password:      session.Password,
+		Port:          session.Port(),
+		WebsocketPort: session.GetWebsocketPort(),
+		CreatedAt:     session.CreatedAt.Format(time.RFC3339),
 	}
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")

--- a/flight-desktop/session_show.go
+++ b/flight-desktop/session_show.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"time"
 
 	"charm.land/log/v2"
 	"github.com/muesli/reflow/wordwrap"
@@ -15,9 +18,11 @@ func showSessionCommand() *cli.Command {
 		Usage:       "Show information about a desktop session",
 		Description: wordwrap.String("Display the connection information for a desktop session.", maxTextWidth),
 		Category:    "Sessions",
+		Flags:       []cli.Flag{formatFlag},
 		Arguments: []cli.Argument{
 			&cli.StringArg{Name: "name", UsageText: "<name>"},
 		},
+		// TODO: Move check inside action.
 		Before:        assertArgPresent("name"),
 		ShellComplete: completeSessionNames,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
@@ -29,6 +34,9 @@ func showSessionCommand() *cli.Command {
 				}
 				return err
 			}
+			if cmd.String("format") == "json" {
+				return writeSessionJSON(session)
+			}
 			sessionInfo(session)
 			if session.State != Exited && session.State != Broken {
 				connectionInfo(session)
@@ -37,6 +45,31 @@ func showSessionCommand() *cli.Command {
 			return nil
 		},
 	}
+}
+
+type shownSession struct {
+	Name        string       `json:"name"`
+	DesktopType string       `json:"desktop_type"`
+	State       sessionState `json:"state"`
+	Host        string       `json:"host"`
+	Port        int          `json:"port"`
+	Password    string       `json:"password"`
+	CreatedAt   string       `json:"created_at"`
+}
+
+func writeSessionJSON(session *Session) error {
+	shownSession := shownSession{
+		Name:        session.Name,
+		DesktopType: session.SessionType,
+		State:       session.ComputedState(),
+		Host:        session.Metadata.Host,
+		Password:    session.Password,
+		Port:        session.Port(),
+		CreatedAt:   session.CreatedAt.Format(time.RFC3339),
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(shownSession)
 }
 
 func completeSessionNames(ctx context.Context, cmd *cli.Command) {

--- a/flight-desktop/testdata/golden/show-help.golden
+++ b/flight-desktop/testdata/golden/show-help.golden
@@ -11,7 +11,8 @@ DESCRIPTION:
    Display the connection information for a desktop session.
 
 OPTIONS:
-   --help, -h  show help
+   --format FORMAT  use specified FORMAT for the output (pretty, json). (default: "pretty")
+   --help, -h       show help
 
 GLOBAL OPTIONS:
    --log-level LEVEL  set the log LEVEL (debug, info, warn, error, fatal). Default: warn

--- a/flight-web-suite/assets/javascript/application.js
+++ b/flight-web-suite/assets/javascript/application.js
@@ -1,1 +1,2 @@
 import "./dropdown";
+import "./novnc-wrapper"

--- a/flight-web-suite/assets/javascript/novnc-wrapper.js
+++ b/flight-web-suite/assets/javascript/novnc-wrapper.js
@@ -1,0 +1,185 @@
+import RFB from '@novnc/novnc'
+
+function noop() {}
+
+function createConnection({
+  url,
+  domEl,
+  onClipboard=noop,
+  onDisconnect=noop,
+  onConnect=noop,
+  onPasswordPrompt=noop,
+  password,
+  viewOnly,
+}) {
+  let rfb = null;
+  try {
+    console.log('connecting to', url);
+    rfb = new RFB(
+      domEl,
+      url,
+      password && {credentials: {password}}
+    );
+    rfb.addEventListener('connect', onConnect);
+    rfb.addEventListener('disconnect', onDisconnect);
+    rfb.addEventListener('credentialsrequired', onPasswordPrompt);
+    rfb.addEventListener('clipboard', onClipboard);
+    // TODO: Add this back. Requires set height and width for domEl (not just 100%).
+    // rfb.scaleViewport = true;
+    rfb.resizeSession = false;
+    rfb.viewOnly = viewOnly;
+  } catch (err) {
+    console.error(`Unable to create RFB client: ${err}`)
+    return onDisconnect({detail: {clean: false}})
+  }
+
+  return rfb
+}
+
+class NoVncContainer {
+  constructor(noVNCCanvas, url, password, copyFallback=noop, viewOnly=false, onDisconnected=noop, onBeforeConnect=noop) {
+    this.url = url
+    this.password = password
+    this.viewOnly = viewOnly
+    this.onDisconnected = onDisconnected
+    this.onBeforeConnect = onBeforeConnect
+
+    this.noVNCCanvas = noVNCCanvas
+    this.copyFallback = copyFallback
+
+    this.status = "connecting"
+  }
+
+  onStatusChange = () => {
+    this.rfb.focus();
+    this.status = "connected"
+    this.onBeforeConnect();
+  };
+
+  onClipboard = async (ev) => {
+    if (ev && ev.detail && ev.detail.text) {
+      try {
+        await navigator.clipboard.write([
+          // eslint-disable-next-line no-undef
+          new ClipboardItem({
+            'text/plain': new Blob([ev.detail.text], { type: 'text/plain' }),
+          })
+        ]);
+      } catch (err) {
+        console.log('err:', err);  // eslint-disable-line no-console
+        try {
+          // Firefox does not support the ClipboardItem API at the time or writing.
+          // It should *hopefully* support it in the future, so it is still attempted.
+          // Until then, a fallback on a text area is used.
+          //
+          // The textarea must be visible in order to copy from it
+          this.copyFallback.current.value = ev.detail.text;
+          this.copyFallback.current.style.display = 'block';
+          this.copyFallback.current.select();
+
+          if (document.execCommand('copy')) {
+            console.log("Copy succeeded!");
+          } else {
+            console.log("Copy failed!");
+          }
+        } catch(fallback_err) {
+          console.log('err:', fallback_err);  // eslint-disable-line no-console
+        }
+        this.copyFallback.current.style.display = 'none';
+        this.copyFallback.current.value = '';
+      }
+    }
+  }
+
+  onDisconnect = (e) => {
+    this.onDisconnected(
+      !e.detail.clean || this.status !== 'connected'
+    )
+    this.status = 'disconnected'
+  }
+
+  onUserDisconnect = () => this.rfb.disconnect();
+
+  onPasswordRequired = () => {
+    console.log("providing password")
+    // XXX Something has gone all kinds of wrong here.  We should have
+    // configured with the password in the first instance.
+    this.rfb.sendCredentials({password: this.password})
+  }
+
+  onReconnect() {
+    this.createConnection();
+  }
+
+  createConnection() {
+    console.log('creating RFB connection');
+    if (this.rfb != null && this.status !== 'disconnected') {
+      this.rfb.disconnect();
+      this.rfb = null;
+    }
+    this.rfb = createConnection({
+      url: this.url,
+      domEl: this.noVNCCanvas,
+      onClipboard: this.onClipboard,
+      onDisconnect: this.onDisconnect,
+      onConnect: this.onStatusChange,
+      onPasswordPrompt: this.onPasswordRequired,
+      password: this.password,
+      viewOnly: this.viewOnly
+    });
+  }
+
+  resize() {
+    if (this.rfb != null && typeof this.rfb._windowResize === 'function') {
+      this.rfb._windowResize();
+    }
+  }
+
+  setClipboardText(text) {
+    if (this.rfb != null) {
+      this.rfb.clipboardPasteFrom(text);
+    }
+  }
+}
+
+function readDataVariable(el, name, defaultValue) {
+  return el.dataset[`novnc${name}`] || defaultValue
+}
+
+function initNoVnc() {
+  const domEl = document.getElementById("novnc-wrapper")
+  if (domEl == null) {
+    return
+  }
+  console.log("initialising NoVNC")
+
+  // Read parameters specified in the URL query string
+  // By default, use the host and port of server that served this file
+  const host = readDataVariable(domEl, 'Host', window.location.hostname);
+  const port = readDataVariable(domEl, 'Port', window.location.port);
+  const password = readDataVariable(domEl, 'Password');
+  const path = readDataVariable(domEl, 'Path', 'websockify');
+
+  // Build the websocket URL used to connect
+  let url;
+  if (window.location.protocol === "https:") {
+    url = 'wss';
+  } else {
+    url = 'ws';
+  }
+  url += '://' + host;
+  if(port) {
+    url += ':' + port;
+  }
+  url += '/' + path;
+
+  const vnc = new NoVncContainer(
+    document.getElementById("novnc-canvas"),
+    url,
+    password,
+    document.getElementById("novnc-canvas"),
+  )
+  vnc.createConnection()
+}
+
+document.addEventListener("DOMContentLoaded", initNoVnc)

--- a/flight-web-suite/assets/javascript/novnc-wrapper.js
+++ b/flight-web-suite/assets/javascript/novnc-wrapper.js
@@ -154,9 +154,8 @@ function initNoVnc() {
   console.log("initialising NoVNC")
 
   // Read parameters specified in the URL query string
-  // By default, use the host and port of server that served this file
-  const host = readDataVariable(domEl, 'Host', window.location.hostname);
-  const port = readDataVariable(domEl, 'Port', window.location.port);
+  const websockifyHost = readDataVariable(domEl, 'Host');
+  const websockifyPort = readDataVariable(domEl, 'Port');
   const password = readDataVariable(domEl, 'Password');
   const path = readDataVariable(domEl, 'Path', 'websockify');
 
@@ -167,11 +166,11 @@ function initNoVnc() {
   } else {
     url = 'ws';
   }
-  url += '://' + host;
-  if(port) {
-    url += ':' + port;
-  }
+  url += '://' + window.location.hostname
+  url += ':' + window.location.port;
   url += '/' + path;
+  url += '?host=' + websockifyHost
+  url += '&port=' + websockifyPort
 
   const vnc = new NoVncContainer(
     document.getElementById("novnc-canvas"),

--- a/flight-web-suite/assets/javascript/novnc-wrapper.js
+++ b/flight-web-suite/assets/javascript/novnc-wrapper.js
@@ -153,7 +153,7 @@ function initNoVnc() {
   }
   console.log("initialising NoVNC")
 
-  // Read parameters specified in the URL query string
+  // Read parameters to be specified in the URL query string passed to NoVNC
   const websockifyHost = readDataVariable(domEl, 'Host');
   const websockifyPort = readDataVariable(domEl, 'Port');
   const password = readDataVariable(domEl, 'Password');

--- a/flight-web-suite/assets/styles/application.css
+++ b/flight-web-suite/assets/styles/application.css
@@ -72,3 +72,8 @@ h2 {
 .btn {
   @apply rounded py-2 px-4 mb-4 cursor-pointer text-white bg-alces-blue hover:bg-alces-blue-dark focus:bg-alces-blue-dark focus:outline-none focus-visible:outline-none;
 }
+
+/* This class assumes .btn has been applied too. */
+.btn-sm {
+  @apply py-1 px-2 mb-2 text-sm;
+}

--- a/flight-web-suite/desktop/list.go
+++ b/flight-web-suite/desktop/list.go
@@ -11,13 +11,14 @@ import (
 )
 
 type Session struct {
-	Name        string    `json:"name"`
-	DesktopType string    `json:"desktop_type"`
-	State       string    `json:"state"`
-	Host        string    `json:"host"`
-	Port        int       `json:"port,omitempty"`
-	Password    string    `json:"password,omitempty"`
-	CreatedAt   time.Time `json:"created_at"`
+	Name          string    `json:"name"`
+	DesktopType   string    `json:"desktop_type"`
+	State         string    `json:"state"`
+	Host          string    `json:"host"`
+	Port          int       `json:"port,omitempty"`
+	WebsocketPort int       `json:"websocket_port,omitempty"`
+	Password      string    `json:"password,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
 }
 
 func ListCommand(ctx context.Context, env configenv.Env, username string) ([]*Session, error) {

--- a/flight-web-suite/desktop/list.go
+++ b/flight-web-suite/desktop/list.go
@@ -15,6 +15,8 @@ type Session struct {
 	DesktopType string    `json:"desktop_type"`
 	State       string    `json:"state"`
 	Host        string    `json:"host"`
+	Port        int       `json:"port,omitempty"`
+	Password    string    `json:"password,omitempty"`
 	CreatedAt   time.Time `json:"created_at"`
 }
 

--- a/flight-web-suite/desktop/show.go
+++ b/flight-web-suite/desktop/show.go
@@ -30,8 +30,5 @@ func ShowCommand(ctx context.Context, env configenv.Env, username, sessionName s
 	if err := json.Unmarshal(stdout.Bytes(), &session); err != nil {
 		return nil, fmt.Errorf("decoding desktop session: %w", err)
 	}
-	if session.Port > 0 {
-		session.Port = session.Port + 3000
-	}
 	return session, nil
 }

--- a/flight-web-suite/desktop/show.go
+++ b/flight-web-suite/desktop/show.go
@@ -1,0 +1,37 @@
+package desktop
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/concertim/flight-user-suite/flight/configenv"
+)
+
+func ShowCommand(ctx context.Context, env configenv.Env, username, sessionName string) (*Session, error) {
+	cmd, err := buildDesktopCommand(ctx, env, username, "show", "--format", "json", sessionName)
+	if err != nil {
+		return nil, err
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if stderr.Len() != 0 {
+			return nil, fmt.Errorf("showing desktop session: %s", stderr.String())
+		}
+		return nil, fmt.Errorf("showing desktop session: %w", err)
+	}
+
+	var session *Session
+	if err := json.Unmarshal(stdout.Bytes(), &session); err != nil {
+		return nil, fmt.Errorf("decoding desktop session: %w", err)
+	}
+	if session.Port > 0 {
+		session.Port = session.Port + 3000
+	}
+	return session, nil
+}

--- a/flight-web-suite/desktop_sessions.go
+++ b/flight-web-suite/desktop_sessions.go
@@ -50,6 +50,28 @@ func indexDesktopSessionsHandler(c *echo.Context) error {
 	return c.Render(http.StatusOK, "desktop/index", data)
 }
 
+func showDesktopSessionHandler(c *echo.Context) error {
+	if !IsLoggedIn(c) {
+		return c.Redirect(http.StatusSeeOther, "/sessions")
+	}
+	if err := requireDesktopToolEnabled(); err != nil {
+		return err
+	}
+
+	session, err := desktop.ShowCommand(c.Request().Context(), env, CurrentUserName(c), c.Param("sessionName"))
+	if err != nil {
+		return err
+	}
+
+	// TODO: Redirect and flash if session cannot be found or is terminated etc..
+
+	data := map[string]any{
+		"layout":         "wide",
+		"DesktopSession": session,
+	}
+	return c.Render(http.StatusOK, "desktop/show", data)
+}
+
 func destroyDesktopSessionHandler(c *echo.Context) error {
 	if !IsLoggedIn(c) {
 		return c.Redirect(http.StatusSeeOther, "/sessions")

--- a/flight-web-suite/main.go
+++ b/flight-web-suite/main.go
@@ -115,6 +115,7 @@ func newApp() *echo.Echo {
 	e.POST("/desktop", createDesktopSessionHandler)
 	e.POST("/desktop/:sessionName/clean", cleanDesktopSessionHandler)
 	e.DELETE("/desktop/:sessionName", destroyDesktopSessionHandler)
+	e.GET("/desktop/:sessionName", showDesktopSessionHandler)
 	e.GET("/sessions", newSessionHandler)
 	e.POST("/sessions", createSessionHandler)
 	e.DELETE("/sessions", destroySessionHandler)

--- a/flight-web-suite/main.go
+++ b/flight-web-suite/main.go
@@ -119,6 +119,8 @@ func newApp() *echo.Echo {
 	e.GET("/sessions", newSessionHandler)
 	e.POST("/sessions", createSessionHandler)
 	e.DELETE("/sessions", destroySessionHandler)
+	e.GET("/websockify", func(c *echo.Context) error { return nil }, NewWSProxyMiddleware())
+
 	return e
 }
 

--- a/flight-web-suite/middleware.go
+++ b/flight-web-suite/middleware.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo/v5"
@@ -32,3 +34,32 @@ func NewSessionMiddleware() echo.MiddlewareFunc {
 		}
 	}
 }
+
+func NewWSProxyMiddleware() echo.MiddlewareFunc {
+	return middleware.ProxyWithConfig(middleware.ProxyConfig{
+		Balancer: &WebsockifyBalancer{},
+		Skipper:  middleware.DefaultSkipper,
+	})
+}
+
+// WebsockifyBalancer dynamically determines the upstream server by examining
+// the incoming request.  It's more of a router than a balancer.
+type WebsockifyBalancer struct{}
+
+func (b *WebsockifyBalancer) Next(c *echo.Context) (*middleware.ProxyTarget, error) {
+	host := c.QueryParam("host")
+	port := c.QueryParam("port")
+	targetURL, err := url.Parse(fmt.Sprintf("http://%s:%s/", host, port))
+	c.Logger().Info("proxying websockify request", "target", targetURL.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return &middleware.ProxyTarget{
+		URL: targetURL,
+	}, nil
+}
+
+// Implement remaining [middleware.ProxyBalancer] interface.
+func (b *WebsockifyBalancer) AddTarget(target *middleware.ProxyTarget) bool { return true }
+func (b *WebsockifyBalancer) RemoveTarget(name string) bool                 { return true }

--- a/flight-web-suite/package-lock.json
+++ b/flight-web-suite/package-lock.json
@@ -4,6 +4,9 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "@novnc/novnc": "^1.5.0"
+      },
       "devDependencies": {
         "esbuild": "0.28.0"
       }
@@ -423,6 +426,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@novnc/novnc": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@novnc/novnc/-/novnc-1.5.0.tgz",
+      "integrity": "sha512-4yGHOtUCnEJUCsgEt/L78eeJu00kthurLBWXFiaXfonNx0pzbs6R/3gJb1byZe6iAE8V9MF0syQb0xIL8MSOtQ==",
+      "license": "MPL-2.0"
     },
     "node_modules/esbuild": {
       "version": "0.28.0",

--- a/flight-web-suite/package.json
+++ b/flight-web-suite/package.json
@@ -1,5 +1,8 @@
 {
   "devDependencies": {
     "esbuild": "0.28.0"
+  },
+  "dependencies": {
+    "@novnc/novnc": "^1.5.0"
   }
 }

--- a/flight-web-suite/views/layouts/wide.gohtml
+++ b/flight-web-suite/views/layouts/wide.gohtml
@@ -1,0 +1,74 @@
+{{define "layouts.wide"}}
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>Flight Web Suite</title>
+    <link rel="icon" type="image/png" href="/assets/images/favicon.png">
+    <link rel="stylesheet" href="/static/styles.css">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <script defer src="/static/js/application.js"></script>
+</head>
+
+<body class="flex flex-col h-screen m-0 p-0 font-sans">
+    <div
+        class="flex items-center w-full h-[3.6rem] bg-black py-2 px-3 box-border border-b-4 border-alces-blue justify-between">
+        <a href="/" class="h-full">
+            <img src="/assets/images/logo.png" alt="Flight Web Suite Logo" class="h-full">
+        </a>
+        {{ if eq .CurrentUserName "" }}
+        <a href="/sessions" class="text-white text-sm px-2" data-testid="sign-in-link">LOG IN</a>
+        {{ else }}
+        <div class="text-white flex justify-end gap-x-3 relative">
+            <button
+                class="dropdown-toggle flex items-center gap-x-1 cursor-pointer px-2"
+                data-testid="signed-in-message"
+                data-target-id="session-dropdown"
+            >
+                {{ .CurrentUserName }}
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="size-3">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+                </svg>
+            </button>
+            <div id="session-dropdown" class="hidden absolute right-0 top-[2.4rem] bg-black z-20">
+                <form action="sessions" method="post" data-testid="logout-form">
+                    <input type="hidden" name="_method" value="DELETE" />
+                    <button class="text-white cursor-pointer hover:bg-slate-800 px-6 py-2" type="submit">Logout</button>
+                </form>
+            </div>
+        </div>
+        {{ end }}
+    </div>
+    {{ template "flashes" .flashes }}
+    <div class="grow min-h-[calc(100vh-3.6rem)] overflow-y-auto">
+        <div class="relative min-h-full flex flex-col bg-linear-to-b from-alces-blue-light to-white">
+            <div class="px-[5%] lg:px-[15%] h-full flex flex-col grow">
+                <div class="bg-white p-4 text-center h-full pb-26 grow">
+                    {{ block "content" . }}{{ end }}
+                </div>
+            </div>
+            <div class="absolute bottom-0 w-full h-22">
+                <div class="bg-[url(/assets/images/cloud_bar.svg)] bg-size-[auto_100%] bg-bottom-left bg-repeat-x w-full h-full"></div>
+            </div>
+        </div>
+        <div class="flex flex-col items-center gap-y-10 pb-16 bg-[#e4f6fe]">
+            <h2>Powered by </h2>
+            <div class="flex flex-wrap gap-x-20 gap-y-6 items-center justify-center">
+                <a href="http://alces-software.com" class="h-12 cursor-pointer" target="_blank">
+                    <img src="/assets/images/powered-logos/alces-logo.png" alt="Alces" class="h-full">
+                </a>
+                <a href="https://www.concertim.com" class="h-12 cursor-pointer" target="_blank">
+                    <img src="/assets/images/powered-logos/concertim-logo.png" alt="ConcertIM" class="h-full">
+                </a>
+                <a href="https://github.com/openflighthpc" class="h-12 cursor-pointer" target="_blank">
+                    <img src="/assets/images/powered-logos/openflighthpc_grey.svg" alt="OpenFlightHPC" class="h-full">
+                </a>
+            </div>
+        </div>
+    </div>
+</body>
+</html>
+
+{{ end }}

--- a/flight-web-suite/views/pages/desktop/index.gohtml
+++ b/flight-web-suite/views/pages/desktop/index.gohtml
@@ -42,6 +42,9 @@
             <dt class="font-semibold">Started</dt>
             <dd data-testid="desktop-session-start-time--{{ .Name }}">{{ .StartTimeText }}</dd>
         </dl>
+        <div class="flex justify-end">
+            <a class="btn btn-sm !mb-0" href="/desktop/{{ .Name }}">View</a>
+        </div>
     </div>
     {{end}}
 </div>

--- a/flight-web-suite/views/pages/desktop/show.gohtml
+++ b/flight-web-suite/views/pages/desktop/show.gohtml
@@ -1,0 +1,22 @@
+{{ define "content" }}
+{{ with .DesktopSession }}
+<div id="novnc-wrapper" class="flex flex-col h-full min-h-full" data-novnc-host="{{ .Host }}"
+    data-novnc-port="{{ .Port }}" data-novnc-path="websockify" data-novnc-password="{{ .Password }}">
+    <div class="bg-alces-blue text-white flex justify-between p-2">
+        <div>
+            <span class="font-semibold">{{ .Name }}</span> running on <code>{{ .Host }}</code>
+        </div>
+        <div>
+            <span title="Placeholder (non-operational) close button">X</span>
+        </div>
+    </div>
+
+    <div class="h-full min-h-full flex-grow">
+        <div id="novnc-canvas" class="novnc h-full min-h-full w-full min-w-full">
+            <!-- This is where the desktop session will appear -->
+        </div>
+        <div id="copy-fallback"></div>
+    </div>
+</div>
+{{end}}
+{{end}}

--- a/flight-web-suite/views/pages/desktop/show.gohtml
+++ b/flight-web-suite/views/pages/desktop/show.gohtml
@@ -1,7 +1,7 @@
 {{ define "content" }}
 {{ with .DesktopSession }}
 <div id="novnc-wrapper" class="flex flex-col h-full min-h-full" data-novnc-host="{{ .Host }}"
-    data-novnc-port="{{ .Port }}" data-novnc-path="websockify" data-novnc-password="{{ .Password }}">
+    data-novnc-port="{{ .WebsocketPort }}" data-novnc-path="websockify" data-novnc-password="{{ .Password }}">
     <div class="bg-alces-blue text-white flex justify-between p-2">
         <div>
             <span class="font-semibold">{{ .Name }}</span> running on <code>{{ .Host }}</code>


### PR DESCRIPTION
This PR supports connecting to a desktop session.

* Start a websockify process when a desktop session starts.
* `desktop show <session>` has learned a `--format` flag. This can be used to return a machine-readable representation of a desktop session, including the host and port of its associated websockify process.
* Add a "View" button to the desktop cards which navigates to the desktop session show page
* Add a desktop show page which uses NoVNC to connect to `ws://<fus_host>:<fus_port>/websockify?host=<websocket_host>&port=<websocket_port>`.
* Add new route to FUS which proxies requests arriving at `/websockify` to a server at `http://<host>:<port>` where host and port are taken from the GET parameters.

TODO:

* Add better user-facing status indications: "connecting", "disconnected", etc..
* Automatically reconnect if connection is dropped.
* Support full screen and/or zen mode.
* Improve layout of show page. In particular, use more of the available width.
* Support termination within show page.
* Support resizing within show page.
* Maybe support renaming?
* Add support for grabbing screenshots and displaying on cards and whilst connecting to/disconnected from session.
* Add support for starting websockify after the fact. If a session has been started before `websockify` has been installed, the VNC session will be running without websockify. We'd like to be able to start websockify by running, say, `flight desktop webify <sessionName>`.