### PR TITLE
Support VNC fullscreen mode

### DIFF
--- a/flight-web-suite/assets/images/icons/arrows-pointing-out.svg
+++ b/flight-web-suite/assets/images/icons/arrows-pointing-out.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  fill="none"
+  viewBox="0 0 24 24"
+  stroke-width="1.5"
+  stroke="currentColor"
+  class="size-6"
+>
+  <path
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15"
+  />
+</svg>

--- a/flight-web-suite/assets/javascript/application.js
+++ b/flight-web-suite/assets/javascript/application.js
@@ -5,12 +5,15 @@ import "./dropdown";
 // Import stimulus controllers. Each entry here needs manually registering
 // below.
 import DisableWithController from "./controllers/disable_with_controller.js"
-import NovncController from "./controllers/novnc_controller"
+import FullscreenController from "./controllers/fullscreen_controller.js"
 import MenuToggleController from "./controllers/menu_toggle_controller.js"
+import NovncController from "./controllers/novnc_controller"
 import RefreshController from "./controllers/refresh_controller.js"
 
 window.Stimulus = Application.start()
 Stimulus.register("disable-with", DisableWithController)
 Stimulus.register("novnc", NovncController)
+Stimulus.register("fullscreen", FullscreenController)
 Stimulus.register("menu-toggle", MenuToggleController)
 Stimulus.register("refresh", RefreshController)
+Stimulus.register("novnc", NovncController)

--- a/flight-web-suite/assets/javascript/controllers/fullscreen_controller.js
+++ b/flight-web-suite/assets/javascript/controllers/fullscreen_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["fullscreenable"]
+  static values = { isFullscreen: { type: Boolean, default: false } }
+
+  initialize() {
+    this.updateFromDocument = this.updateFromDocument.bind(this)
+  }
+
+  connect() {
+    document.addEventListener('fullscreenchange', this.updateFromDocument)
+  }
+
+  disconnect() {
+    document.removeEventListener('fullscreenchange', this.updateFromDocument)
+  }
+
+  isFullscreenValueChanged(isFullscreen) {
+    if (isFullscreen) {
+      this.fullscreenableTarget.requestFullscreen().catch(
+        () => {
+          // Fullscreening failed FSR
+          this.isFullscreenValue = false
+        }
+      )
+    }
+  }
+
+  toggle() {
+    this.isFullscreenValue = !this.isFullscreenValue
+  }
+
+  updateFromDocument() {
+    this.isFullscreenValue = this.fullscreenableTarget === document.fullscreenElement
+  }
+}

--- a/flight-web-suite/assets/javascript/controllers/fullscreen_controller.js
+++ b/flight-web-suite/assets/javascript/controllers/fullscreen_controller.js
@@ -25,6 +25,11 @@ export default class extends Controller {
         }
       )
     }
+    else if (this.fullscreenableTarget === document.fullscreenElement) {
+      // Not sure how this would be triggered given the fullscreen VNC canvas
+      // covers the button, but for completeness:
+      document.exitFullscreen()
+    }
   }
 
   toggle() {

--- a/flight-web-suite/views/pages/desktop/show.gohtml
+++ b/flight-web-suite/views/pages/desktop/show.gohtml
@@ -1,6 +1,6 @@
 {{ define "content" }}
 {{ with .DesktopSession }}
-<div id="novnc-wrapper" class="absolute top-0 bottom-22 left-0 right-0" data-controller="novnc"
+<div id="novnc-wrapper" class="absolute top-0 bottom-22 left-0 right-0" data-controller="novnc fullscreen"
     data-novnc-host-value="{{ .Host }}"
     data-novnc-port-value="{{ .WebsocketPort }}"
     data-novnc-path-value="websockify"
@@ -54,6 +54,10 @@
               </div>
             </div>
 
+            <button class="btn btn-sm !mb-0 text-white" data-action="fullscreen#toggle">
+                fs
+            </button>
+
             <a class="btn btn-sm !mb-0 text-white" href="/desktop" title="Close">
                 {{ template "x-mark.svg" }}
             </a>
@@ -67,7 +71,7 @@
                 <span class="px-6 py-2 bg-white rounded-full font-semibold text-xl" data-novnc-target="status">Connecting...</span>
             </div>
         </div>
-        <div class="novnc h-full" data-novnc-target="canvas">
+        <div class="novnc h-full" data-novnc-target="canvas" data-fullscreen-target="fullscreenable">
             <!-- This is where the desktop session will appear -->
         </div>
         <div style="display:none" data-novnc-target="copyFallback"></div>

--- a/flight-web-suite/views/pages/desktop/show.gohtml
+++ b/flight-web-suite/views/pages/desktop/show.gohtml
@@ -13,6 +13,11 @@
             <span class="mb-[-2px]"><code>{{ .Host }}</code></span>
         </div>
         <div class="flex-grow flex justify-end">
+
+            <button class="btn btn-sm !mb-0 text-white" data-action="fullscreen#toggle" title="Full screen">
+                {{ template "arrows-pointing-out.svg" }}
+            </button>
+
             <div
               class="cursor-pointer group/menu flex items-center relative"
               data-controller="menu-toggle"
@@ -20,7 +25,7 @@
               id="toolbar-actions-dropdown-2"
             >
               <button
-                class="flex items-center mx-0 link size-6 cursor-pointer"
+                class="btn btn-sm !mb-0 text-white"
                 data-action="click->menu-toggle#toggle click@window->menu-toggle#close"
                 type="button"
                 >
@@ -53,10 +58,6 @@
                 </div>
               </div>
             </div>
-
-            <button class="btn btn-sm !mb-0 text-white" data-action="fullscreen#toggle">
-                fs
-            </button>
 
             <a class="btn btn-sm !mb-0 text-white" href="/desktop" title="Close">
                 {{ template "x-mark.svg" }}


### PR DESCRIPTION
This PR adds the capability to set the VNC canvas to full-screen, via a new button on the toolbar. It is based on the branch under review in #163.

<img width="922" height="762" alt="image" src="https://github.com/user-attachments/assets/b9b57f55-9028-485c-b000-d2b82e0f4b02" />

It behaves, hopefully, as you'd expect. The Stimulus controller also listens for the `fullscreenchange` event on `document` to detect when fullscreen mode has been exited outside of its own code.

Resolves #154 (at this point I think "zen mode" is something to implement iff we get asked for it specifically...)