### PR TITLE
[Flight Web] List and show howto guides

### DIFF
--- a/flight-howto/integration_test.go
+++ b/flight-howto/integration_test.go
@@ -1,6 +1,7 @@
 package main_test
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -105,6 +106,291 @@ func Test_golden_tests(t *testing.T) {
 	}
 }
 
+func Test_list_json(t *testing.T) {
+	output, err := runBinary([]string{"list", "--format", "json"}, nil)
+	assertExitCode(t, 0, output, err)
+
+	var response struct {
+		Success bool `json:"success"`
+		Guides  []struct {
+			Index int    `json:"index"`
+			Title string `json:"title"`
+		} `json:"guides"`
+		Error  string `json:"error"`
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal(output, &response); err != nil {
+		t.Fatalf("unmarshal output: %v\noutput:\n%s", err, output)
+	}
+
+	if !response.Success {
+		t.Fatalf("expected success response: %#v", response)
+	}
+	if response.Error != "" || response.Reason != "" {
+		t.Fatalf("unexpected error fields: %#v", response)
+	}
+
+	guides := response.Guides
+	if len(guides) != 3 {
+		t.Fatalf("unexpected guides: %#v", guides)
+	}
+	if guides[0].Index != 1 || guides[0].Title != "Base Guide A" {
+		t.Fatalf("unexpected first guide: %#v", guides)
+	}
+	if guides[1].Index != 2 || guides[1].Title != "Base Guide B" {
+		t.Fatalf("unexpected second guide: %#v", guides)
+	}
+	if guides[2].Index != 3 || guides[2].Title != "My Category > Guide" {
+		t.Fatalf("unexpected third guide: %#v", guides)
+	}
+
+	for _, guide := range guides {
+		if guide.Title == "Admin Guides > Admin Guide" {
+			t.Fatalf("admin-only guide should be filtered from json output: %#v", guides)
+		}
+	}
+}
+
+func Test_show_json_success(t *testing.T) {
+	output, err := runBinary([]string{"show", "--format", "json", "1"}, nil)
+	assertExitCode(t, 0, output, err)
+
+	var response struct {
+		Success bool `json:"success"`
+		Guide   struct {
+			Title       string `json:"title"`
+			RawMarkdown string `json:"raw_markdown"`
+		} `json:"guide"`
+	}
+	if err := json.Unmarshal(output, &response); err != nil {
+		t.Fatalf("unmarshal output: %v\noutput:\n%s", err, output)
+	}
+
+	if !response.Success {
+		t.Fatalf("expected success response: %#v", response)
+	}
+	if response.Guide.Title != "Base Guide A" {
+		t.Fatalf("unexpected title: %#v", response)
+	}
+	if response.Guide.RawMarkdown != "Base guide A\n" {
+		t.Fatalf("unexpected raw markdown: %#v", response)
+	}
+}
+
+func Test_show_json_invalid_index(t *testing.T) {
+	output, err := runBinary([]string{"show", "--format", "json", "0"}, nil)
+	assertExitCode(t, 1, output, err)
+
+	var response struct {
+		Success bool `json:"success"`
+		Guide   struct {
+			Title       string `json:"title"`
+			RawMarkdown string `json:"raw_markdown"`
+		} `json:"guide"`
+		Error  string `json:"error"`
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal(extractJSONOutput(output), &response); err != nil {
+		t.Fatalf("unmarshal output: %v\noutput:\n%s", err, output)
+	}
+
+	if response.Success {
+		t.Fatalf("expected failure response: %#v", response)
+	}
+	if response.Reason != "invalid_index" {
+		t.Fatalf("unexpected reason: %#v", response)
+	}
+	if response.Guide != (struct {
+		Title       string "json:\"title\""
+		RawMarkdown string "json:\"raw_markdown\""
+	}{}) {
+		t.Fatalf("expected empty guide on failure: %#v", response)
+	}
+}
+
+func Test_show_json_missing_index(t *testing.T) {
+	output, err := runBinary([]string{"show", "--format", "json"}, nil)
+	assertExitCode(t, 1, output, err)
+
+	var response struct {
+		Success bool `json:"success"`
+		Guide   struct {
+			Title       string `json:"title"`
+			RawMarkdown string `json:"raw_markdown"`
+		} `json:"guide"`
+		Error  string `json:"error"`
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal(extractJSONOutput(output), &response); err != nil {
+		t.Fatalf("unmarshal output: %v\noutput:\n%s", err, output)
+	}
+
+	if response.Success {
+		t.Fatalf("expected failure response: %#v", response)
+	}
+	if response.Reason != "unexpected" {
+		t.Fatalf("unexpected reason: %#v", response)
+	}
+	if response.Error != "Incorrect usage: missing argument index" {
+		t.Fatalf("unexpected error: %#v", response)
+	}
+}
+
+func Test_show_json_invalid_index_flag_after_arg(t *testing.T) {
+	output, err := runBinary([]string{"show", "-1", "--format", "json"}, nil)
+	assertExitCode(t, 1, output, err)
+
+	var response struct {
+		Success bool `json:"success"`
+		Guide   struct {
+			Title       string `json:"title"`
+			RawMarkdown string `json:"raw_markdown"`
+		} `json:"guide"`
+		Error  string `json:"error"`
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal(extractJSONOutput(output), &response); err != nil {
+		t.Fatalf("unmarshal output: %v\noutput:\n%s", err, output)
+	}
+
+	if response.Success {
+		t.Fatalf("expected failure response: %#v", response)
+	}
+	if response.Reason != "invalid_index" {
+		t.Fatalf("unexpected reason: %#v", response)
+	}
+}
+
+func Test_show_json_not_found(t *testing.T) {
+	linkPath := filepath.Join(flightRoot, "usr", "share", "doc", "howtos-enabled", "01-base-guide-a.md")
+	if err := os.Remove(linkPath); err != nil {
+		t.Fatal(err)
+	}
+	originalPath := filepath.Join(testdataPath, "howtos", "01-base-guide-a.md")
+	t.Cleanup(func() {
+		_ = os.Remove(linkPath)
+		if err := os.Symlink(originalPath, linkPath); err != nil {
+			t.Fatalf("restore guide symlink: %v", err)
+		}
+	})
+	if err := os.Symlink(filepath.Join(tmpDir, "missing-guide.md"), linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := runBinary([]string{"show", "--format", "json", "1"}, nil)
+	assertExitCode(t, 1, output, err)
+
+	var response struct {
+		Success bool `json:"success"`
+		Guide   struct {
+			Title       string `json:"title"`
+			RawMarkdown string `json:"raw_markdown"`
+		} `json:"guide"`
+		Error  string `json:"error"`
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal(extractJSONOutput(output), &response); err != nil {
+		t.Fatalf("unmarshal output: %v\noutput:\n%s", err, output)
+	}
+
+	if response.Success {
+		t.Fatalf("expected failure response: %#v", response)
+	}
+	if response.Reason != "not_found" {
+		t.Fatalf("unexpected reason: %#v", response)
+	}
+	if response.Error != "Unknown howto: 01-base-guide-a.md" {
+		t.Fatalf("unexpected error: %#v", response)
+	}
+	if response.Guide != (struct {
+		Title       string "json:\"title\""
+		RawMarkdown string "json:\"raw_markdown\""
+	}{}) {
+		t.Fatalf("expected empty guide on failure: %#v", response)
+	}
+}
+
+func Test_show_json_collecting_guides_error(t *testing.T) {
+	missingRoot := filepath.Join(tmpDir, "missing-root")
+	output, err := runBinaryWithEnv(
+		[]string{"show", "-1", "--format", "json"},
+		nil,
+		[]string{fmt.Sprintf("FLIGHT_ROOT=%s", missingRoot)},
+	)
+	assertExitCode(t, 1, output, err)
+
+	var response struct {
+		Success bool `json:"success"`
+		Guide   struct {
+			Title       string `json:"title"`
+			RawMarkdown string `json:"raw_markdown"`
+		} `json:"guide"`
+		Error  string `json:"error"`
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal(extractJSONOutput(output), &response); err != nil {
+		t.Fatalf("unmarshal output: %v\noutput:\n%s", err, output)
+	}
+
+	if response.Success {
+		t.Fatalf("expected failure response: %#v", response)
+	}
+	if response.Reason != "unexpected" {
+		t.Fatalf("unexpected reason: %#v", response)
+	}
+	expectedError := fmt.Sprintf(
+		"collecting guide files: reading directory: open %s/usr/share/doc/howtos-enabled: no such file or directory",
+		missingRoot,
+	)
+	if response.Error != expectedError {
+		t.Fatalf("unexpected error: %#v", response)
+	}
+}
+
+func Test_list_json_load_error(t *testing.T) {
+	missingRoot := filepath.Join(tmpDir, "missing-root")
+	output, err := runBinaryWithEnv(
+		[]string{"list", "--format", "json"},
+		nil,
+		[]string{fmt.Sprintf("FLIGHT_ROOT=%s", missingRoot)},
+	)
+	assertExitCode(t, 1, output, err)
+
+	var response struct {
+		Success bool `json:"success"`
+		Guides  []struct {
+			Index int    `json:"index"`
+			Title string `json:"title"`
+		} `json:"guides"`
+		Error  string `json:"error"`
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal(extractJSONOutput(output), &response); err != nil {
+		t.Fatalf("unmarshal output: %v\noutput:\n%s", err, output)
+	}
+
+	if response.Success {
+		t.Fatalf("expected failure response: %#v", response)
+	}
+	if response.Reason != "unexpected" {
+		t.Fatalf("unexpected reason: %#v", response)
+	}
+	if len(response.Guides) != 0 {
+		t.Fatalf("expected empty guides on failure: %#v", response)
+	}
+	expectedError := fmt.Sprintf(
+		"reading directory: open %s/usr/share/doc/howtos-enabled: no such file or directory",
+		missingRoot,
+	)
+	if response.Error != expectedError {
+		t.Fatalf("unexpected error: %#v", response)
+	}
+}
+
+func extractJSONOutput(output []byte) []byte {
+	return []byte(strings.TrimSuffix(string(output), "exit status 1\n"))
+}
+
 func fixturePath(fixture string) string {
 	return filepath.Join(testdataPath, fixture)
 }
@@ -129,6 +415,17 @@ func runBinary(args []string, stdin *string) ([]byte, error) {
 	fullArgs := append([]string{"run", entryPoint}, args...)
 	cmd := exec.Command("go", fullArgs...)
 	cmd.Env = append(os.Environ(), "GOCOVERDIR=.coverdata", fmt.Sprintf("FLIGHT_ROOT=%s", flightRoot), fmt.Sprintf("FLIGHT_STATE_ROOT=%s", flightStateRoot))
+	if stdin != nil {
+		cmd.Stdin = strings.NewReader(*stdin)
+	}
+	return cmd.CombinedOutput()
+}
+
+func runBinaryWithEnv(args []string, stdin *string, extraEnv []string) ([]byte, error) {
+	fullArgs := append([]string{"run", entryPoint}, args...)
+	cmd := exec.Command("go", fullArgs...)
+	cmd.Env = append(os.Environ(), "GOCOVERDIR=.coverdata", fmt.Sprintf("FLIGHT_ROOT=%s", flightRoot), fmt.Sprintf("FLIGHT_STATE_ROOT=%s", flightStateRoot))
+	cmd.Env = append(cmd.Env, extraEnv...)
 	if stdin != nil {
 		cmd.Stdin = strings.NewReader(*stdin)
 	}

--- a/flight-howto/main.go
+++ b/flight-howto/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -29,6 +30,18 @@ var (
 	termWidth        int = 80
 	maxTextWidth     int = 80
 )
+
+var formatFlag = &cli.StringFlag{
+	Name:  "format",
+	Value: "pretty",
+	Usage: "use specified `FORMAT` for the output (pretty, json).",
+	Validator: func(format string) error {
+		if format != "pretty" && format != "json" {
+			return fmt.Errorf("%s is not a known format (pretty, json)", format)
+		}
+		return nil
+	},
+}
 
 func init() {
 	log.SetReportTimestamp(false)
@@ -60,6 +73,7 @@ func main() {
 				Name:    "list",
 				Aliases: []string{"l", "ls"},
 				Usage:   "List available user guides",
+				Flags:   []cli.Flag{formatFlag},
 				Action:  list,
 			},
 			{
@@ -67,6 +81,7 @@ func main() {
 				Aliases:   []string{"s"},
 				Usage:     "Open a user guide for viewing in the terminal",
 				ArgsUsage: "<index>",
+				Flags:     []cli.Flag{formatFlag},
 				Action:    show,
 				Before:    assertArgPresent("index"),
 			},
@@ -94,38 +109,56 @@ func main() {
 			os.Exit(1)
 		}
 
+		if exitError, ok := errors.AsType[SilentExitError](err); ok {
+			os.Exit(exitError.ExitCode)
+		}
+
 		log.Printf("%s\n", err)
 		os.Exit(1)
 	}
 }
 
 func list(ctx context.Context, cmd *cli.Command) error {
+	wantsJSON := wantsJSONOutput(cmd)
 	user, err := user.Current()
 	if err != nil {
 		log.Warn("Unable to determine user: including admin guides", "err", err)
 	}
 	howtos, err := loadHowtos(howtoDir, user)
 	if err != nil {
+		if wantsJSON {
+			return writeListHowtosJSONError(err)
+		}
 		return err
+	}
+	if wantsJSON {
+		return writeListHowtosJSON(howtos)
 	}
 	return entriesTable(howtos)
 }
 
 func show(ctx context.Context, cmd *cli.Command) error {
+	wantsJSON := wantsJSONOutput(cmd)
 	user, err := user.Current()
 	if err != nil {
 		log.Warn("Unable to determine user: including admin guides", "err", err)
 	}
 	howtos, err := loadHowtos(howtoDir, user)
 	if err != nil {
-		return fmt.Errorf("collecting guide files: %w", err)
+		err = fmt.Errorf("collecting guide files: %w", err)
+		if wantsJSON {
+			return writeShowHowtoJSON(nil, err)
+		}
+		return err
 	}
 
 	howtoIndex, err := strconv.Atoi(cmd.Args().First())
 	if err != nil || howtoIndex < 1 || howtoIndex > len(howtos) {
-		return fmt.Errorf(
-			"invalid input: '%s' is not a valid guide index. Use `flight howto list` to view the index for each user guide.",
-			cmd.Args().First())
+		err = InvalidIndex{Input: cmd.Args().First()}
+		if wantsJSON {
+			return writeShowHowtoJSON(nil, err)
+		}
+		return err
 	}
 
 	howto := howtos[howtoIndex-1]
@@ -133,10 +166,25 @@ func show(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		if pathError, ok := errors.AsType[*fs.PathError](err); ok {
 			if pathError.Err.Error() == "no such file or directory" {
-				return UnknownHowto{Howto: howto.Path}
+				err = UnknownHowto{Howto: howto.Path}
+				if wantsJSON {
+					return writeShowHowtoJSON(nil, err)
+				}
+				return err
 			}
 		}
-		return fmt.Errorf("reading howto: %w", err)
+		err = fmt.Errorf("reading howto: %w", err)
+		if wantsJSON {
+			return writeShowHowtoJSON(nil, err)
+		}
+		return err
+	}
+
+	if wantsJSON {
+		return writeShowHowtoJSON(&shownHowto{
+			Title:       howto.Name(),
+			RawMarkdown: string(markdown),
+		}, nil)
 	}
 
 	isDark := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
@@ -152,6 +200,39 @@ func show(ctx context.Context, cmd *cli.Command) error {
 
 	fmt.Print(rendered)
 	return nil
+}
+
+// Work around a limitation in how urfave/cli processes arguments and flags.
+//
+// If an argument starting with `-`, e.g., `-1` comes prior to the flags, the
+// flags may not be processed correctly.  So the following both work:
+//
+//	show --format json -1
+//	show 1 --format json
+//
+// but not this
+//
+//	show -1 --format json
+//
+// This function jumps through hoops to make the latter work.
+func wantsJSONOutput(cmd *cli.Command) bool {
+	if cmd.String("format") == "json" {
+		return true
+	}
+
+	format := ""
+	for index := 0; index < len(os.Args); index++ {
+		arg := os.Args[index]
+		if value, ok := strings.CutPrefix(arg, "--format="); ok {
+			format = value
+			continue
+		}
+		if arg == "--format" && index+1 < len(os.Args) {
+			format = os.Args[index+1]
+			index++
+		}
+	}
+	return format == "json"
 }
 
 func loadHowtos(dirPath string, user *user.User) ([]*Howto, error) {
@@ -224,6 +305,103 @@ func entriesTable(howtos []*Howto) error {
 	return err
 }
 
+type listedHowto struct {
+	Index int    `json:"index"`
+	Title string `json:"title"`
+}
+
+type listHowtoResponse struct {
+	Success bool          `json:"success"`
+	Guides  []listedHowto `json:"guides"`
+	Error   string        `json:"error,omitempty"`
+	Reason  string        `json:"reason,omitempty"`
+}
+
+type showHowtoResponse struct {
+	Success bool       `json:"success"`
+	Guide   shownHowto `json:"guide"`
+	Error   string     `json:"error,omitempty"`
+	Reason  string     `json:"reason,omitempty"`
+}
+
+type shownHowto struct {
+	Title       string `json:"title"`
+	RawMarkdown string `json:"raw_markdown"`
+}
+
+func writeListHowtosJSON(howtos []*Howto) error {
+	guides := make([]listedHowto, 0, len(howtos))
+	for index, howto := range howtos {
+		guides = append(guides, listedHowto{
+			Index: index + 1,
+			Title: howto.Name(),
+		})
+	}
+	response := listHowtoResponse{
+		Success: true,
+		Guides:  guides,
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(response)
+}
+
+func writeListHowtosJSONError(listErr error) error {
+	response := listHowtoResponse{
+		Success: false,
+		Guides:  []listedHowto{},
+		Error:   listErr.Error(),
+		Reason:  "unexpected",
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(response); err != nil {
+		return err
+	}
+	return SilentExitError{
+		ExitCode:  1,
+		exitError: errors.New("listing howtos failed"),
+	}
+}
+
+func writeShowHowtoJSON(guide *shownHowto, showErr error) error {
+	if showErr != nil {
+		response := showHowtoResponse{
+			Success: false,
+			Guide:   shownHowto{},
+			Error:   showErr.Error(),
+			Reason:  "unexpected",
+		}
+		if _, ok := errors.AsType[InvalidIndex](showErr); ok {
+			response.Reason = "invalid_index"
+		} else if _, ok := errors.AsType[UnknownHowto](showErr); ok {
+			response.Reason = "not_found"
+		}
+		return writeHowtoShowResponse(response, 1)
+	}
+
+	response := showHowtoResponse{
+		Success: true,
+		Guide:   *guide,
+	}
+	return writeHowtoShowResponse(response, 0)
+}
+
+func writeHowtoShowResponse(response showHowtoResponse, exitCode int) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(response); err != nil {
+		return err
+	}
+	if exitCode == 0 {
+		return nil
+	}
+	return SilentExitError{
+		ExitCode:  exitCode,
+		exitError: errors.New("showing howto failed"),
+	}
+}
+
 // TODO properly share these with flight-core
 type MissingArguments struct {
 	Args []string
@@ -241,6 +419,9 @@ func assertArgPresent(argNames ...string) cli.BeforeFunc {
 	return func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
 		if cmd.NArg() < len(argNames) {
 			missing := argNames[cmd.NArg():]
+			if wantsJSONOutput(cmd) {
+				return ctx, writeShowHowtoJSON(nil, MissingArguments{Args: missing})
+			}
 			return ctx, MissingArguments{Args: missing}
 		}
 		return ctx, nil
@@ -253,4 +434,24 @@ type UnknownHowto struct {
 
 func (ut UnknownHowto) Error() string {
 	return fmt.Sprintf("Unknown howto: %s", ut.Howto)
+}
+
+type InvalidIndex struct {
+	Input string
+}
+
+func (ii InvalidIndex) Error() string {
+	return fmt.Sprintf(
+		"invalid input: '%s' is not a valid guide index. Use `flight howto list` to view the index for each user guide.",
+		ii.Input,
+	)
+}
+
+type SilentExitError struct {
+	ExitCode  int
+	exitError error
+}
+
+func (ee SilentExitError) Error() string {
+	return ee.exitError.Error()
 }

--- a/flight-howto/testdata/golden/list-help.golden
+++ b/flight-howto/testdata/golden/list-help.golden
@@ -5,4 +5,5 @@ USAGE:
    flight howto list [options]
 
 OPTIONS:
-   --help, -h  show help
+   --format FORMAT  use specified FORMAT for the output (pretty, json). (default: "pretty")
+   --help, -h       show help

--- a/flight-howto/testdata/golden/show-help.golden
+++ b/flight-howto/testdata/golden/show-help.golden
@@ -5,4 +5,5 @@ USAGE:
    flight howto show [options] <index>
 
 OPTIONS:
-   --help, -h  show help
+   --format FORMAT  use specified FORMAT for the output (pretty, json). (default: "pretty")
+   --help, -h       show help

--- a/flight-web-suite/assets/styles/application.css
+++ b/flight-web-suite/assets/styles/application.css
@@ -128,3 +128,61 @@ h2 {
     @apply font-semibold;
   }
 }
+
+.markdown {
+  h1, h2, h3, h4, h5, h6 {
+    @apply text-slate-700 font-semibold mt-8 mb-3;
+  }
+
+  h1 {
+    @apply text-3xl mt-0;
+  }
+
+  h2 {
+    @apply text-2xl;
+  }
+
+  h3 {
+    @apply text-xl;
+  }
+
+  p, ul, ol, blockquote, pre {
+    @apply mb-4;
+  }
+
+  ul, ol {
+    @apply pl-6;
+  }
+
+  ul {
+    @apply list-disc;
+  }
+
+  ol {
+    @apply list-decimal;
+  }
+
+  li + li {
+    @apply mt-1;
+  }
+
+  a {
+    @apply text-alces-blue underline hover:text-alces-blue-dark;
+  }
+
+  code {
+    @apply rounded bg-slate-100 px-1 py-0.5 text-sm text-fuchsia-700;
+  }
+
+  pre {
+    @apply overflow-x-auto rounded-2xl bg-slate-900 p-4 text-slate-100;
+  }
+
+  pre code {
+    @apply bg-transparent p-0 text-inherit;
+  }
+
+  blockquote {
+    @apply border-l-4 border-alces-blue-light pl-4 italic text-slate-600;
+  }
+}

--- a/flight-web-suite/desktop/build_command.go
+++ b/flight-web-suite/desktop/build_command.go
@@ -21,7 +21,7 @@ func desktopToolPath(env configenv.Env) string {
 	return filepath.Join(env.FlightRoot, "usr", "lib", "flight-core", "flight-desktop")
 }
 
-func buildDesktopCommand(ctx context.Context, env configenv.Env, username string, args ...string) (*exec.Cmd, error) {
+func BuildCommand(ctx context.Context, toolPath, username string, args ...string) (*exec.Cmd, error) {
 	userInfo, err := user.Lookup(username)
 	if err != nil {
 		return nil, fmt.Errorf("looking up user %q: %w", username, err)
@@ -49,7 +49,7 @@ func buildDesktopCommand(ctx context.Context, env configenv.Env, username string
 		groups = append(groups, uint32(parsed))
 	}
 
-	cmd := exec.CommandContext(ctx, desktopToolPath(env), args...)
+	cmd := exec.CommandContext(ctx, toolPath, args...)
 	cmd.Dir = userInfo.HomeDir
 	cmd.Env = commandEnv(userInfo)
 	if os.Geteuid() == 0 {
@@ -61,9 +61,13 @@ func buildDesktopCommand(ctx context.Context, env configenv.Env, username string
 			},
 		}
 	} else if os.Geteuid() != uid {
-		return nil, fmt.Errorf("cannot run desktop command as %q without root privileges", userInfo.Username)
+		return nil, fmt.Errorf("cannot run command as %q without root privileges", userInfo.Username)
 	}
 	return cmd, nil
+}
+
+func buildDesktopCommand(ctx context.Context, env configenv.Env, username string, args ...string) (*exec.Cmd, error) {
+	return BuildCommand(ctx, desktopToolPath(env), username, args...)
 }
 
 func commandEnv(userInfo *user.User) []string {

--- a/flight-web-suite/go.mod
+++ b/flight-web-suite/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/labstack/echo/v5 v5.1.0
+	github.com/yuin/goldmark v1.7.13
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/flight-web-suite/go.sum
+++ b/flight-web-suite/go.sum
@@ -20,6 +20,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
+github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=

--- a/flight-web-suite/helpers.go
+++ b/flight-web-suite/helpers.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"html/template"
 	"strings"
 
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo/v5"
+	"github.com/yuin/goldmark"
 )
 
 const sessionContextKey = "_session"
@@ -112,4 +115,12 @@ func AddCommonData(c *echo.Context, data map[string]any) map[string]any {
 		"alert":  strings.Join(Flashes(c, "alert"), ", "),
 	}
 	return data
+}
+
+func renderMarkdown(raw string) (template.HTML, error) {
+	var output bytes.Buffer
+	if err := goldmark.Convert([]byte(raw), &output); err != nil {
+		return "", err
+	}
+	return template.HTML(output.String()), nil
 }

--- a/flight-web-suite/home_functional_test.go
+++ b/flight-web-suite/home_functional_test.go
@@ -107,7 +107,7 @@ func assertAuthenticated(t *testing.T, body, username string) {
 		testutil.HasText(username),
 	)
 	testutil.AssertSelection(t, body, `form[data-testid="logout-form"]`,
-		testutil.HasAttr("action", "sessions"),
+		testutil.HasAttr("action", "/sessions"),
 		testutil.HasAttr("method", "post"),
 	)
 	testutil.AssertSelection(t, body, `form[data-testid="logout-form"] input[name="_method"]`,

--- a/flight-web-suite/howto/build_command.go
+++ b/flight-web-suite/howto/build_command.go
@@ -1,0 +1,23 @@
+package howto
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/concertim/flight-user-suite/flight-web-suite/desktop"
+	"github.com/concertim/flight-user-suite/flight/configenv"
+)
+
+func howtoToolPath(env configenv.Env) string {
+	return filepath.Join(env.FlightRoot, "usr", "lib", "flight-core", "flight-howto")
+}
+
+func buildHowtoCommand(ctx context.Context, env configenv.Env, username string, args ...string) (*exec.Cmd, error) {
+	cmd, err := desktop.BuildCommand(ctx, howtoToolPath(env), username, args...)
+	if err != nil {
+		return nil, fmt.Errorf("building howto command: %w", err)
+	}
+	return cmd, nil
+}

--- a/flight-web-suite/howto/integration_test.go
+++ b/flight-web-suite/howto/integration_test.go
@@ -1,0 +1,169 @@
+package howto
+
+import (
+	"context"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/concertim/flight-user-suite/flight/configenv"
+)
+
+func TestListCommandDecodesSuccessfulEnvelope(t *testing.T) {
+	env := howtoEnvForTest(t, howtoToolFixture(t, 0o755, `#!/bin/sh
+cat <<'JSON'
+{
+  "success": true,
+  "guides": [
+    {
+      "index": 1,
+      "title": "Base Guide A"
+    }
+  ]
+}
+JSON
+`))
+
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatalf("failed to determine current user: %v", err)
+	}
+
+	response, err := ListCommand(context.Background(), env, currentUser.Username)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !response.Success {
+		t.Fatalf("expected success response, got %+v", response)
+	}
+	if len(response.Guides) != 1 || response.Guides[0].Index != 1 || response.Guides[0].Title != "Base Guide A" {
+		t.Fatalf("unexpected guides: %+v", response.Guides)
+	}
+}
+
+func TestListCommandDecodesFailureEnvelopeFromNonZeroExit(t *testing.T) {
+	env := howtoEnvForTest(t, howtoToolFixture(t, 0o755, `#!/bin/sh
+cat <<'JSON'
+{
+  "success": false,
+  "guides": [],
+  "error": "No such file or directory",
+  "reason": "unexpected"
+}
+JSON
+exit 1
+`))
+
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatalf("failed to determine current user: %v", err)
+	}
+
+	response, err := ListCommand(context.Background(), env, currentUser.Username)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if response.Success {
+		t.Fatalf("expected failure response, got %+v", response)
+	}
+	if response.Error != "No such file or directory" || response.Reason != "unexpected" {
+		t.Fatalf("unexpected response: %+v", response)
+	}
+}
+
+func TestShowCommandDecodesSuccessfulEnvelope(t *testing.T) {
+	env := howtoEnvForTest(t, howtoToolFixture(t, 0o755, `#!/bin/sh
+cat <<'JSON'
+{
+  "success": true,
+  "guide": {
+    "title": "Base Guide A",
+    "raw_markdown": "# Heading\n\nBody text\n"
+  }
+}
+JSON
+`))
+
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatalf("failed to determine current user: %v", err)
+	}
+
+	response, err := ShowCommand(context.Background(), env, currentUser.Username, 1)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !response.Success {
+		t.Fatalf("expected success response, got %+v", response)
+	}
+	if response.Guide.Title != "Base Guide A" || response.Guide.RawMarkdown != "# Heading\n\nBody text\n" {
+		t.Fatalf("unexpected guide: %+v", response.Guide)
+	}
+}
+
+func TestShowCommandDecodesFailureEnvelopeFromNonZeroExit(t *testing.T) {
+	env := howtoEnvForTest(t, howtoToolFixture(t, 0o755, `#!/bin/sh
+cat <<'JSON'
+{
+  "success": false,
+  "guide": {},
+  "error": "Unknown howto: 01-base-guide-a.md",
+  "reason": "not_found"
+}
+JSON
+exit 1
+`))
+
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatalf("failed to determine current user: %v", err)
+	}
+
+	response, err := ShowCommand(context.Background(), env, currentUser.Username, 1)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if response.Success {
+		t.Fatalf("expected failure response, got %+v", response)
+	}
+	if response.Error != "Unknown howto: 01-base-guide-a.md" || response.Reason != "not_found" {
+		t.Fatalf("unexpected response: %+v", response)
+	}
+}
+
+func howtoEnvForTest(t *testing.T, root string) configenv.Env {
+	t.Helper()
+
+	env, err := configenv.InitFlightEnv()
+	if err != nil {
+		t.Fatalf("failed to init env: %v", err)
+	}
+	env.FlightRoot = root
+	return env
+}
+
+func howtoToolFixture(t *testing.T, mode os.FileMode, script string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	toolPath := filepath.Join(root, "usr", "lib", "flight-core", "flight-howto")
+	if err := os.MkdirAll(filepath.Dir(toolPath), 0o755); err != nil {
+		t.Fatalf("failed to create tool dir: %v", err)
+	}
+	if err := os.WriteFile(toolPath, []byte(script), mode); err != nil {
+		t.Fatalf("failed to write howto tool fixture: %v", err)
+	}
+	return root
+}
+
+func envContains(env []string, key, want string) bool {
+	prefix := key + "="
+	for _, entry := range env {
+		if after, ok := strings.CutPrefix(entry, prefix); ok {
+			return after == want
+		}
+	}
+	return false
+}

--- a/flight-web-suite/howto/list.go
+++ b/flight-web-suite/howto/list.go
@@ -1,0 +1,52 @@
+package howto
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/concertim/flight-user-suite/flight/configenv"
+)
+
+type GuideSummary struct {
+	Index int    `json:"index"`
+	Title string `json:"title"`
+}
+
+type ListResponse struct {
+	Success bool           `json:"success"`
+	Guides  []GuideSummary `json:"guides"`
+	Error   string         `json:"error"`
+	Reason  string         `json:"reason"`
+}
+
+func ListCommand(ctx context.Context, env configenv.Env, username string) (ListResponse, error) {
+	cmd, err := buildHowtoCommand(ctx, env, username, "list", "--format", "json")
+	if err != nil {
+		return ListResponse{}, err
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	var response ListResponse
+	decodeErr := json.Unmarshal(stdout.Bytes(), &response)
+	if decodeErr == nil {
+		if response.Guides == nil {
+			response.Guides = []GuideSummary{}
+		}
+		return response, nil
+	}
+
+	if runErr != nil {
+		if stderr.Len() != 0 {
+			return ListResponse{}, fmt.Errorf("running howto list command: %s", stderr.String())
+		}
+		return ListResponse{}, fmt.Errorf("running howto list command: %w", runErr)
+	}
+	return ListResponse{}, fmt.Errorf("decoding howto list response: %w", decodeErr)
+}

--- a/flight-web-suite/howto/show.go
+++ b/flight-web-suite/howto/show.go
@@ -1,0 +1,50 @@
+package howto
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/concertim/flight-user-suite/flight/configenv"
+)
+
+type Guide struct {
+	Title       string `json:"title"`
+	RawMarkdown string `json:"raw_markdown"`
+}
+
+type ShowResponse struct {
+	Success bool   `json:"success"`
+	Guide   Guide  `json:"guide"`
+	Error   string `json:"error"`
+	Reason  string `json:"reason"`
+}
+
+func ShowCommand(ctx context.Context, env configenv.Env, username string, index int) (ShowResponse, error) {
+	cmd, err := buildHowtoCommand(ctx, env, username, "show", "--format", "json", strconv.Itoa(index))
+	if err != nil {
+		return ShowResponse{}, err
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	var response ShowResponse
+	decodeErr := json.Unmarshal(stdout.Bytes(), &response)
+	if decodeErr == nil {
+		return response, nil
+	}
+
+	if runErr != nil {
+		if stderr.Len() != 0 {
+			return ShowResponse{}, fmt.Errorf("running howto show command: %s", stderr.String())
+		}
+		return ShowResponse{}, fmt.Errorf("running howto show command: %w", runErr)
+	}
+	return ShowResponse{}, fmt.Errorf("decoding howto show response: %w", decodeErr)
+}

--- a/flight-web-suite/howto_functional_test.go
+++ b/flight-web-suite/howto_functional_test.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/concertim/flight-user-suite/flight-web-suite/internal/testutil"
+)
+
+func TestHowtoIndexRedirectsForAnonymous(t *testing.T) {
+	resp, _ := testutil.RenderPage(t, newApp(), http.MethodGet, "/howto", nil, http.StatusSeeOther)
+
+	if resp.Header.Get("location") != "/sessions" {
+		t.Errorf("expected howto page to redirect to '/sessions' for anonymous users")
+	}
+}
+
+func TestHowtoShowRedirectsForAnonymous(t *testing.T) {
+	resp, _ := testutil.RenderPage(t, newApp(), http.MethodGet, "/howto/1", nil, http.StatusSeeOther)
+
+	if resp.Header.Get("location") != "/sessions" {
+		t.Errorf("expected howto guide page to redirect to '/sessions' for anonymous users")
+	}
+}
+
+func TestHowtoIndexReturnsServiceUnavailableWhenToolDisabled(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForHowtoTest(t, howtoToolFixtureForWeb(t, 0o644, "#!/bin/sh\necho '{}'\n"))
+
+	_, body := testutil.RenderPage(t, newApp(), http.MethodGet, "/howto", nil, http.StatusServiceUnavailable, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	if want := "Flight Howto is not enabled"; !strings.Contains(body, want) {
+		t.Fatalf("expected body to contain %q, got %q", want, body)
+	}
+}
+
+func TestHowtoShowReturnsServiceUnavailableWhenToolDisabled(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForHowtoTest(t, howtoToolFixtureForWeb(t, 0o644, "#!/bin/sh\necho '{}'\n"))
+
+	_, body := testutil.RenderPage(t, newApp(), http.MethodGet, "/howto/1", nil, http.StatusServiceUnavailable, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	if want := "Flight Howto is not enabled"; !strings.Contains(body, want) {
+		t.Fatalf("expected body to contain %q, got %q", want, body)
+	}
+}
+
+func TestHowtoIndexRendersSidebarGuideListAndSelectionPrompt(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForHowtoTest(t, howtoToolFixtureForWeb(t, 0o755, `#!/bin/sh
+cat <<'JSON'
+{
+  "success": true,
+  "guides": [
+    {"index": 1, "title": "Base Guide A"},
+    {"index": 2, "title": "Cluster Basics"}
+  ]
+}
+JSON
+`))
+
+	_, body := testutil.RenderPage(t, newApp(), http.MethodGet, "/howto", nil, http.StatusOK, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	assertAuthenticated(t, body, currentUser.Username)
+	testutil.AssertSelection(t, body, `[data-testid="howto-guide-link--1"]`,
+		testutil.HasAttr("href", "/howto/1"),
+		testutil.HasText("Base Guide A"),
+		testutil.HasNoAttr("aria-current"),
+	)
+	testutil.AssertSelection(t, body, `[data-testid="howto-guide-link--2"]`,
+		testutil.HasAttr("href", "/howto/2"),
+		testutil.HasText("Cluster Basics"),
+		testutil.HasNoAttr("aria-current"),
+	)
+	testutil.AssertSelection(t, body, `[data-testid="howto-selection-prompt"]`,
+		testutil.HasText("Choose a guide from the sidebar to view its contents."),
+	)
+}
+
+func TestHowtoIndexRendersEmptyStateWhenNoGuidesAvailable(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForHowtoTest(t, howtoToolFixtureForWeb(t, 0o755, `#!/bin/sh
+cat <<'JSON'
+{
+  "success": true,
+  "guides": []
+}
+JSON
+`))
+
+	_, body := testutil.RenderPage(t, newApp(), http.MethodGet, "/howto", nil, http.StatusOK, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	testutil.AssertSelection(t, body, `[data-testid="howto-sidebar-empty"]`,
+		testutil.HasText("No guides are currently available."),
+	)
+	testutil.AssertSelection(t, body, `[data-testid="howto-empty-state"]`,
+		testutil.HasText("Return later or contact your administrator for more information."),
+	)
+}
+
+func TestHowtoShowRendersSidebarSelectedGuideAndMarkdownHTML(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForHowtoTest(t, howtoToolFixtureForWeb(t, 0o755, "#!/bin/sh\n"+
+		"if [ \"$1\" = \"list\" ]; then\n"+
+		"cat <<'JSON'\n"+
+		"{\n"+
+		"  \"success\": true,\n"+
+		"  \"guides\": [\n"+
+		"    {\"index\": 1, \"title\": \"Base Guide A\"},\n"+
+		"    {\"index\": 2, \"title\": \"Cluster Basics\"}\n"+
+		"  ]\n"+
+		"}\n"+
+		"JSON\n"+
+		"  exit 0\n"+
+		"fi\n"+
+		"cat <<'JSON'\n"+
+		"{\n"+
+		"  \"success\": true,\n"+
+		"  \"guide\": {\n"+
+		"    \"title\": \"Cluster Basics\",\n"+
+		"    \"raw_markdown\": \"# Heading\\n\\nParagraph with [link](https://example.invalid).\\n\\n- Item one\\n- Item two\\n\\n> Quote\\n\\n`inline`\\n\\n```bash\\necho hi\\n```\\n\"\n"+
+		"  }\n"+
+		"}\n"+
+		"JSON\n"))
+
+	_, body := testutil.RenderPage(t, newApp(), http.MethodGet, "/howto/2", nil, http.StatusOK, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	testutil.AssertSelection(t, body, `[data-testid="howto-guide-link--2"]`,
+		testutil.HasText("Cluster Basics"),
+		testutil.HasAttr("aria-current", "page"),
+	)
+	testutil.AssertSelection(t, body, `[data-testid="howto-guide-content"] h1`,
+		testutil.HasText("Heading"),
+	)
+	testutil.AssertSelection(t, body, `[data-testid="howto-guide-content"] p a`,
+		testutil.HasAttr("href", "https://example.invalid"),
+		testutil.HasText("link"),
+	)
+	testutil.AssertSelection(t, body, `[data-testid="howto-guide-content"] ul li:first-child`,
+		testutil.HasText("Item one"),
+	)
+	testutil.AssertSelection(t, body, `[data-testid="howto-guide-content"] blockquote p`,
+		testutil.HasText("Quote"),
+	)
+	testutil.AssertSelection(t, body, `[data-testid="howto-guide-content"] pre code`,
+		testutil.HasText("echo hi"),
+	)
+}
+
+func TestHowtoShowRedirectsToIndexForInvalidGuideIndex(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setFlightRootForHowtoTest(t, howtoToolFixtureForWeb(t, 0o755, `#!/bin/sh
+cat <<'JSON'
+{
+  "success": true,
+  "guides": [
+    {"index": 1, "title": "Base Guide A"}
+  ]
+}
+JSON
+`))
+
+	resp, _ := testutil.RenderPage(t, newApp(), http.MethodGet, "/howto/2", nil, http.StatusSeeOther, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	if got := resp.Header.Get("location"); got != "/howto" {
+		t.Fatalf("expected redirect to /howto, got %q", got)
+	}
+}
+
+func TestHowtoIndexInvokesListJSONOnly(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	argsFile := filepath.Join(t.TempDir(), "howto-args.txt")
+	setFlightRootForHowtoTest(t, howtoToolFixtureForWeb(t, 0o755, "#!/bin/sh\n"+
+		"printf '%s\\n' \"$@\" > \""+argsFile+"\"\n"+
+		"cat <<'JSON'\n"+
+		"{\n"+
+		"  \"success\": true,\n"+
+		"  \"guides\": []\n"+
+		"}\n"+
+		"JSON\n"))
+
+	testutil.RenderPage(t, newApp(), http.MethodGet, "/howto", nil, http.StatusOK, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("failed to read command args fixture: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "list\n--format\njson" {
+		t.Fatalf("expected list command args, got %q", got)
+	}
+}
+
+func TestHowtoShowInvokesListBeforeShowJSON(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	argsFile := filepath.Join(t.TempDir(), "howto-args.txt")
+	setFlightRootForHowtoTest(t, howtoToolFixtureForWeb(t, 0o755, "#!/bin/sh\n"+
+		"{\n"+
+		"  printf '%s\\n' \"$@\"\n"+
+		"  printf '%s\\n' '---'\n"+
+		"} >> \""+argsFile+"\"\n"+
+		"if [ \"$1\" = \"list\" ]; then\n"+
+		"cat <<'JSON'\n"+
+		"{\n"+
+		"  \"success\": true,\n"+
+		"  \"guides\": [\n"+
+		"    {\"index\": 3, \"title\": \"Base Guide A\"}\n"+
+		"  ]\n"+
+		"}\n"+
+		"JSON\n"+
+		"  exit 0\n"+
+		"fi\n"+
+		"cat <<'JSON'\n"+
+		"{\n"+
+		"  \"success\": true,\n"+
+		"  \"guide\": {\n"+
+		"    \"title\": \"Base Guide A\",\n"+
+		"    \"raw_markdown\": \"Body\\n\"\n"+
+		"  }\n"+
+		"}\n"+
+		"JSON\n"))
+
+	testutil.RenderPage(t, newApp(), http.MethodGet, "/howto/3", nil, http.StatusOK, testutil.WithSessionCookie(currentUser.Username, config.Session.Secret))
+
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("failed to read command args fixture: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "list\n--format\njson\n---\nshow\n--format\njson\n3\n---" {
+		t.Fatalf("expected list then show command args, got %q", got)
+	}
+}
+
+func setFlightRootForHowtoTest(t *testing.T, root string) {
+	t.Helper()
+
+	original := env.FlightRoot
+	env.FlightRoot = root
+	t.Cleanup(func() {
+		env.FlightRoot = original
+	})
+}
+
+func howtoToolFixtureForWeb(t *testing.T, mode os.FileMode, script string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	toolPath := filepath.Join(root, "usr", "lib", "flight-core", "flight-howto")
+	if err := os.MkdirAll(filepath.Dir(toolPath), 0o755); err != nil {
+		t.Fatalf("failed to create howto tool dir: %v", err)
+	}
+	if err := os.WriteFile(toolPath, []byte(script), mode); err != nil {
+		t.Fatalf("failed to write howto tool fixture: %v", err)
+	}
+	synopsisDir := filepath.Join(root, "usr", "share", "doc", "tools")
+	if err := os.MkdirAll(synopsisDir, 0o755); err != nil {
+		t.Fatalf("failed to create synopsis dir: %v", err)
+	}
+	synopsisPath := filepath.Join(synopsisDir, "flight-howto")
+	if err := os.WriteFile(synopsisPath, []byte("Learn about the Flight User Suite and using your cluster"), 0o644); err != nil {
+		t.Fatalf("failed to write synopsis fixture: %v", err)
+	}
+	return root
+}

--- a/flight-web-suite/howto_handlers.go
+++ b/flight-web-suite/howto_handlers.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"slices"
+	"strconv"
+
+	"github.com/concertim/flight-user-suite/flight-web-suite/howto"
+	"github.com/concertim/flight-user-suite/flight/toolset"
+	"github.com/labstack/echo/v5"
+)
+
+type howtoPageGuide struct {
+	Index      int
+	Title      string
+	URL        string
+	IsSelected bool
+}
+
+func indexHowtoHandler(c *echo.Context) error {
+	if !IsLoggedIn(c) {
+		return c.Redirect(http.StatusSeeOther, "/sessions")
+	}
+	if err := requireHowtoToolEnabled(); err != nil {
+		return err
+	}
+
+	response, err := howto.ListCommand(c.Request().Context(), env, CurrentUserName(c))
+	if err != nil {
+		return err
+	}
+	if !response.Success {
+		return fmt.Errorf("listing howtos: %s", response.Error)
+	}
+
+	return renderHowtoPage(c, response.Guides, 0, "")
+}
+
+func showHowtoHandler(c *echo.Context) error {
+	if !IsLoggedIn(c) {
+		return c.Redirect(http.StatusSeeOther, "/sessions")
+	}
+	if err := requireHowtoToolEnabled(); err != nil {
+		return err
+	}
+
+	response, err := howto.ListCommand(c.Request().Context(), env, CurrentUserName(c))
+	if err != nil {
+		return err
+	}
+	if !response.Success {
+		return fmt.Errorf("listing howtos: %s", response.Error)
+	}
+	if len(response.Guides) == 0 {
+		return renderHowtoPage(c, response.Guides, 0, "")
+	}
+
+	index, err := strconv.Atoi(c.Param("index"))
+	if err != nil || index <= 0 || !containsGuideIndex(response.Guides, index) {
+		return redirectHowtoIndexAlert(c, "Howto guide not found.")
+	}
+
+	showResponse, err := howto.ShowCommand(c.Request().Context(), env, CurrentUserName(c), index)
+	if err != nil {
+		return err
+	}
+	if !showResponse.Success {
+		if showResponse.Reason == "not_found" || showResponse.Reason == "invalid_index" {
+			return redirectHowtoIndexAlert(c, "Howto guide not found.")
+		}
+		return fmt.Errorf("showing howto %d: %s", index, showResponse.Error)
+	}
+
+	rendered, err := renderMarkdown(showResponse.Guide.RawMarkdown)
+	if err != nil {
+		return err
+	}
+	return renderHowtoPage(c, response.Guides, index, rendered)
+}
+
+func requireHowtoToolEnabled() error {
+	tool, err := toolset.GetTool(env.FlightRoot, "howto")
+	if err != nil || !tool.Enabled {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "Flight Howto is not enabled")
+	}
+	return nil
+}
+
+func redirectHowtoIndexAlert(c *echo.Context, message string) error {
+	sess, err := GetSession(c)
+	if err != nil {
+		return err
+	}
+	sess.AddFlash(message, "alert")
+	SaveSession(c, sess)
+	return c.Redirect(http.StatusSeeOther, "/howto")
+}
+
+func containsGuideIndex(guides []howto.GuideSummary, index int) bool {
+	return slices.ContainsFunc(guides, func(guide howto.GuideSummary) bool {
+		return guide.Index == index
+	})
+}
+
+func renderHowtoPage(c *echo.Context, guides []howto.GuideSummary, selectedIndex int, content template.HTML) error {
+	pageGuides := make([]howtoPageGuide, 0, len(guides))
+	for _, guide := range guides {
+		pageGuides = append(pageGuides, howtoPageGuide{
+			Index:      guide.Index,
+			Title:      guide.Title,
+			URL:        fmt.Sprintf("/howto/%d", guide.Index),
+			IsSelected: guide.Index == selectedIndex,
+		})
+	}
+
+	data := map[string]any{
+		"layout":          "howto",
+		"HasGuides":       len(pageGuides) > 0,
+		"Guides":          pageGuides,
+		"GuideContent":    content,
+		"HasSelection":    selectedIndex > 0,
+		"SelectedIndex":   selectedIndex,
+		"ShowEmptyState":  len(pageGuides) == 0,
+		"ShowSelectState": len(pageGuides) > 0 && selectedIndex == 0,
+	}
+	return c.Render(http.StatusOK, "howto/index", data)
+}

--- a/flight-web-suite/howto_integration_test.go
+++ b/flight-web-suite/howto_integration_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/concertim/flight-user-suite/flight-web-suite/internal/testutil"
+)
+
+func TestHowtoShowInvalidIndexAddsFlashAndRedirects(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setAuthenticatorPathForTest(t, filepath.Join("testdata", "authenticator_success.sh"))
+	setFlightRootForHowtoTest(t, howtoToolFixtureForWeb(t, 0o755, `#!/bin/sh
+cat <<'JSON'
+{
+  "success": true,
+  "guides": [
+    {"index": 1, "title": "Base Guide A"}
+  ]
+}
+JSON
+`))
+
+	srv, client := testutil.SetupIntegrationServer(t, newApp())
+	client.PostForm(srv.URL+"/sessions", url.Values{
+		"username": {currentUser.Username},
+		"password": {"fakepassword"},
+	})
+	client.FollowRedirect()
+	client.Get(srv.URL + "/howto/2")
+
+	client.AssertRedirect(t, http.StatusSeeOther, "/howto")
+	_, body := client.FollowRedirect()
+	testutil.AssertSelection(t, body, `div.flash.alert`,
+		testutil.HasText("Howto guide not found."),
+	)
+}
+
+func TestHowtoShowNotFoundAddsFlashAndRedirects(t *testing.T) {
+	currentUser := currentUserForTest(t)
+	setAuthenticatorPathForTest(t, filepath.Join("testdata", "authenticator_success.sh"))
+	setFlightRootForHowtoTest(t, howtoToolFixtureForWeb(t, 0o755, `#!/bin/sh
+if [ "$1" = "list" ]; then
+cat <<'JSON'
+{
+  "success": true,
+  "guides": [
+    {"index": 1, "title": "Base Guide A"}
+  ]
+}
+JSON
+  exit 0
+fi
+cat <<'JSON'
+{
+  "success": false,
+  "guide": {},
+  "error": "Unknown howto: 01-base-guide-a.md",
+  "reason": "not_found"
+}
+JSON
+exit 1
+`))
+
+	srv, client := testutil.SetupIntegrationServer(t, newApp())
+	client.PostForm(srv.URL+"/sessions", url.Values{
+		"username": {currentUser.Username},
+		"password": {"fakepassword"},
+	})
+	client.FollowRedirect()
+	client.Get(srv.URL + "/howto/1")
+
+	client.AssertRedirect(t, http.StatusSeeOther, "/howto")
+	_, body := client.FollowRedirect()
+	testutil.AssertSelection(t, body, `div.flash.alert`,
+		testutil.HasText("Howto guide not found."),
+	)
+}

--- a/flight-web-suite/main.go
+++ b/flight-web-suite/main.go
@@ -140,6 +140,8 @@ func newApp() *echo.Echo {
 		}
 		return c.Render(http.StatusOK, "home", data)
 	})
+	e.GET("/howto", indexHowtoHandler)
+	e.GET("/howto/:index", showHowtoHandler)
 	e.GET("/desktop", indexDesktopSessionsHandler)
 	e.GET("/desktop/new", newDesktopSessionHandler)
 	e.POST("/desktop", createDesktopSessionHandler)

--- a/flight-web-suite/views/layouts/application.gohtml
+++ b/flight-web-suite/views/layouts/application.gohtml
@@ -32,7 +32,7 @@
                 <div class="size-3 text-white">{{ template "chevron-down.svg" }}</div>
             </button>
             <div id="session-dropdown" class="hidden absolute right-0 top-[2.4rem] bg-black z-20">
-                <form action="sessions" method="post" data-testid="logout-form">
+                <form action="/sessions" method="post" data-testid="logout-form">
                     <input type="hidden" name="_method" value="DELETE" />
                     <button class="dropdown-option text-white hover:bg-slate-800" type="submit">Logout</button>
                 </form>

--- a/flight-web-suite/views/layouts/howto.gohtml
+++ b/flight-web-suite/views/layouts/howto.gohtml
@@ -1,0 +1,76 @@
+{{define "layouts.howto"}}
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>Flight Web Suite</title>
+    <link rel="icon" type="image/png" href="/assets/images/favicon.png">
+    <link rel="stylesheet" href="/static/styles.css">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <script defer src="/static/js/application.js"></script>
+</head>
+
+<body class="flex flex-col h-screen m-0 p-0 font-sans">
+    <div
+        class="flex items-center w-full h-[3.6rem] bg-black py-2 px-3 box-border border-b-4 border-alces-blue justify-between">
+        <a href="/" class="h-full">
+            <img src="/assets/images/logo.png" alt="Flight Web Suite Logo" class="h-full">
+        </a>
+        {{ if eq .CurrentUserName "" }}
+        <a href="/sessions" class="text-white text-sm px-2" data-testid="sign-in-link">LOG IN</a>
+        {{ else }}
+        <div class="text-white flex justify-end gap-x-3 relative">
+            <button
+                class="dropdown-toggle flex items-center gap-x-1 cursor-pointer px-2"
+                data-testid="signed-in-message"
+                data-target-id="session-dropdown"
+                title="Open user menu"
+            >
+                {{ .CurrentUserName }}
+                <div class="size-3 text-white">{{ template "chevron-down.svg" }}</div>
+            </button>
+            <div id="session-dropdown" class="hidden absolute right-0 top-[2.4rem] bg-black z-20">
+                <form action="/sessions" method="post" data-testid="logout-form">
+                    <input type="hidden" name="_method" value="DELETE" />
+                    <button class="dropdown-option text-white hover:bg-slate-800" type="submit">Logout</button>
+                </form>
+            </div>
+        </div>
+        {{ end }}
+    </div>
+    <div class="grow min-h-[calc(100vh-3.6rem)] overflow-y-auto">
+        <div class="relative min-h-full lg:grid lg:grid-cols-[16rem_minmax(0,_1fr)] bg-linear-to-b from-alces-blue-light to-white">
+            <div class="mx-1 mt-0 mb-4 lg:mx-2 lg:my-8">
+                {{ block "sidebar" . }}{{ end }}
+            </div>
+            <div class="h-full flex flex-col grow">
+                <div class="bg-white py-4 px-4 md:px-8 h-full pb-26 grow relative">
+                    {{ template "flashes" .flashes }}
+                    {{ block "content" . }}{{ end }}
+                </div>
+            </div>
+            <div class="absolute bottom-0 w-full h-22">
+                <div class="bg-[url(/assets/images/cloud_bar.svg)] bg-size-[auto_100%] bg-bottom-left bg-repeat-x w-full h-full"></div>
+            </div>
+        </div>
+        <div class="flex flex-col items-center gap-y-10 pb-16 bg-[#e4f6fe]">
+            <h2>Powered by </h2>
+            <div class="flex flex-wrap gap-x-20 gap-y-6 items-center justify-center">
+                <a href="http://alces-software.com" class="h-12 cursor-pointer" target="_blank">
+                    <img src="/assets/images/powered-logos/alces-logo.png" alt="Alces" class="h-full">
+                </a>
+                <a href="https://www.concertim.com" class="h-12 cursor-pointer" target="_blank">
+                    <img src="/assets/images/powered-logos/concertim-logo.png" alt="ConcertIM" class="h-full">
+                </a>
+                <a href="https://github.com/openflighthpc" class="h-12 cursor-pointer" target="_blank">
+                    <img src="/assets/images/powered-logos/openflighthpc_grey.svg" alt="OpenFlightHPC" class="h-full">
+                </a>
+            </div>
+        </div>
+    </div>
+</body>
+</html>
+
+{{ end }}

--- a/flight-web-suite/views/layouts/vnc_session.gohtml
+++ b/flight-web-suite/views/layouts/vnc_session.gohtml
@@ -33,7 +33,7 @@
                 </svg>
             </button>
             <div id="session-dropdown" class="hidden absolute right-0 top-[2.4rem] bg-black z-20">
-                <form action="sessions" method="post" data-testid="logout-form">
+                <form action="/sessions" method="post" data-testid="logout-form">
                     <input type="hidden" name="_method" value="DELETE" />
                     <button class="text-white cursor-pointer hover:bg-slate-800 px-6 py-2" type="submit">Logout</button>
                 </form>

--- a/flight-web-suite/views/pages/howto/index.gohtml
+++ b/flight-web-suite/views/pages/howto/index.gohtml
@@ -1,0 +1,50 @@
+{{ define "sidebar" }}
+    {{ if .HasGuides }}
+        <nav aria-label="Howto guides">
+            <ul class="space-y-2">
+                {{ range .Guides }}
+                    <li>
+                        <a
+                            href="{{ .URL }}"
+                            class="block rounded-2xl border px-4 py-3 transition-colors {{ if .IsSelected }}border-alces-blue bg-white text-alces-blue-dark{{ else }}border-transparent hover:border-alces-blue-light hover:bg-white{{ end }}"
+                            data-testid="howto-guide-link--{{ .Index }}"
+                            {{ if .IsSelected }}aria-current="page"{{ end }}
+                        >{{ .Title }}</a>
+                    </li>
+                {{ end }}
+            </ul>
+        </nav>
+    {{ else }}
+        <p class="m-0 text-sm text-slate-600" data-testid="howto-sidebar-empty">No guides are currently available.</p>
+    {{ end }}
+{{ end }}
+
+{{ define "content" }}
+<div class="max-w-[60rem] mx-auto">
+    <div class="flex gap-x-4 items-center justify-center w-full mt-12 mb-12">
+        <img src="/assets/images/howto.png" class="size-16" alt="">
+        <div>
+            <h1 class="mb-1">Flight Howto</h1>
+            <p class="m-0">Learn about the Flight User Suite and using your cluster</p>
+        </div>
+    </div>
+
+    <main class="bg-white p-6 lg:p-8 pt-0 lg:pt-0" data-testid="howto-main-pane">
+        {{ if .ShowEmptyState }}
+            <div class="max-w-2xl">
+                <h2 class="mb-3">No howto guides available</h2>
+                <p class="m-0 text-slate-600" data-testid="howto-empty-state">Return later or contact your administrator for more information.</p>
+            </div>
+        {{ else if .ShowSelectState }}
+            <div class="max-w-2xl">
+                <h2 class="mb-3">Select a howto guide</h2>
+                <p class="m-0 text-slate-600" data-testid="howto-selection-prompt">Choose a guide from the sidebar to view its contents.</p>
+            </div>
+        {{ else }}
+            <article class="markdown" data-testid="howto-guide-content">
+                {{ .GuideContent }}
+            </article>
+        {{ end }}
+    </main>
+</div>
+{{ end }}


### PR DESCRIPTION
This PR adds support for listing and showing howto guides.

<img width="1256" height="1022" alt="image" src="https://github.com/user-attachments/assets/cbd81ea5-b863-449e-8149-7f5487b154e1" />

<img width="1256" height="1022" alt="image" src="https://github.com/user-attachments/assets/83fb577e-6832-421f-898f-49dd5a385b66" />

<img width="1256" height="1022" alt="image" src="https://github.com/user-attachments/assets/2b045366-88d6-4f68-9e3f-f84ed31e85f0" />

Support for showing nested guides is currently sub-optimal, but they are currently only available to users logged into Flight Web Suite as the root user.

<img width="1256" height="1022" alt="image" src="https://github.com/user-attachments/assets/3b7c949d-87c5-4304-a34e-f31aa9e60240" />

Closes #141 
Closes #142 
