### PR TITLE
Better VNC session launch feedback

### DIFF
--- a/flight-web-suite/assets/javascript/application.js
+++ b/flight-web-suite/assets/javascript/application.js
@@ -4,11 +4,13 @@ import "./dropdown";
 
 // Import stimulus controllers. Each entry here needs manually registering
 // below.
+import DisableWithController from "./controllers/disable_with_controller.js"
 import NovncController from "./controllers/novnc_controller"
 import MenuToggleController from "./controllers/menu_toggle_controller.js"
 import RefreshController from "./controllers/refresh_controller.js"
 
 window.Stimulus = Application.start()
+Stimulus.register("disable-with", DisableWithController)
 Stimulus.register("novnc", NovncController)
 Stimulus.register("menu-toggle", MenuToggleController)
 Stimulus.register("refresh", RefreshController)

--- a/flight-web-suite/assets/javascript/controllers/disable_with_controller.js
+++ b/flight-web-suite/assets/javascript/controllers/disable_with_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    const button = this.element
+    if (button.dataset.disableWith) {
+      button.addEventListener('click', () => {
+        // Delay actually disabling the button until the form submission has
+        // gone through.
+        setTimeout(
+          () => { button.disabled = true },
+          1
+        )
+
+        button.innerText = button.dataset.disableWith
+        if (button.dataset.disableWithClass) {
+          button.classList.add(button.dataset.disableWithClass)
+        }
+      })
+    }
+  }
+}

--- a/flight-web-suite/assets/javascript/controllers/novnc_controller.js
+++ b/flight-web-suite/assets/javascript/controllers/novnc_controller.js
@@ -42,11 +42,18 @@ export default class extends Controller {
     if (newValue != null && newValue.type === "connect") {
       this.rfb.focus();
       this.statusValue = "connected"
+      this.autoreconnecting = false
     }
   }
 
   onRfbDisconnect(e) {
     this.statusValue = "disconnected"
+    if (e.detail.clean != null && !e.detail.clean && !this.autoreconnecting) {
+      setTimeout(() => {
+        this.autoreconnecting = true
+        this.reconnect()
+      }, 500)
+    }
   }
 
   onRfbPasswordRequired() {

--- a/flight-web-suite/desktop_launch.go
+++ b/flight-web-suite/desktop_launch.go
@@ -90,7 +90,7 @@ func createDesktopSessionHandler(c *echo.Context) error {
 			}
 			sess.AddFlash(fmt.Sprintf("Desktop session '%s' launched.", response.SessionName), "notice")
 			SaveSession(c, sess)
-			return c.Redirect(http.StatusSeeOther, "/desktop")
+			return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/desktop/%s", response.SessionName))
 		}
 		applyDesktopStartErrors(&form, response)
 	}

--- a/flight-web-suite/desktop_launch_functional_test.go
+++ b/flight-web-suite/desktop_launch_functional_test.go
@@ -173,8 +173,8 @@ JSON
 		testutil.WithSessionCookie(currentUser.Username, config.Session.Secret),
 	)
 
-	if resp.Header.Get("location") != "/desktop" {
-		t.Fatalf("expected redirect to /desktop, got %q", resp.Header.Get("location"))
+	if resp.Header.Get("location") != "/desktop/xterm.abc123" {
+		t.Fatalf("expected redirect to /desktop/xterm.abc123, got %q", resp.Header.Get("location"))
 	}
 
 	data, err := os.ReadFile(argsFile)

--- a/flight-web-suite/desktop_launch_integration_test.go
+++ b/flight-web-suite/desktop_launch_integration_test.go
@@ -49,7 +49,7 @@ JSON
 		"geometry":     {"1024x768"},
 	})
 
-	client.AssertRedirect(t, http.StatusSeeOther, "/desktop")
+	client.AssertRedirect(t, http.StatusSeeOther, "/desktop/named-session")
 	_, body := client.FollowRedirect()
 	testutil.AssertSelection(t, body, `div.flash.notice`,
 		testutil.HasText("Desktop session 'named-session' launched."),

--- a/flight-web-suite/views/pages/desktop/new.gohtml
+++ b/flight-web-suite/views/pages/desktop/new.gohtml
@@ -117,13 +117,16 @@
             </div>
             <button
                 type="submit"
-                class="btn !px-12 {{if eq .HasDesktopTypes false}}btn-disabled{{end}}"
+                class="btn !px-12 uppercase {{if eq .HasDesktopTypes false}}btn-disabled{{end}}"
+                data-controller="disable-with"
+                data-disable-with="Launching..."
+                data-disable-with-class="btn-disabled"
                 data-testid="desktop-launch-submit"
                 {{if eq .HasDesktopTypes false}}
                     disabled
                     title="No available desktop types"
                 {{end}}
-            >LAUNCH</button>
+            >Launch</button>
         </form>
         {{ if false }}
             <aside class="border border-alces-blue-light bg-sky-50 p-6">


### PR DESCRIPTION
This PR makes a couple of improvements to VNC session launching via Flight Web Suite.

- When the launch form is submitted, change the text of the submit button and disable it to avoid multiple submissions and to provide visual feedback that something has happened.
  <img width="922" height="762" alt="image" src="https://github.com/user-attachments/assets/dc1d422e-2f68-4f53-9a51-45e11d7e161d" />

- Redirect to the show page for the new session, not the session index page.
 
I've deliberately followed Rails-y conventions for the button disabling, even though that makes the data attributes inconsistent with Stimulus' standard practice. Having a `data-disable-with` attribute just feels more familiar than `data-disable-with-caption-value` or similar!

Resolves #146.