### PR TITLE
Add screenshots to desktop index page

### DIFF
--- a/flight-web-suite/views/pages/desktop/index.gohtml
+++ b/flight-web-suite/views/pages/desktop/index.gohtml
@@ -57,13 +57,29 @@
                     </div>
                 </div>
             </div>
-            <dl class="details-grid grid grid-cols-[auto_1fr] gap-x-6 gap-y-2">
+            <a
+                class="mb-4 flex justify-center h-40 overflow-clip"
+                href="/desktop/{{ .Name }}"
+            >
+                <img
+                    class="h-full max-w-fit"
+                    src="/desktop/{{ .Name }}/screenshot"
+                    data-controller="refresh"
+                    data-refresh-interval-value="{{300000}}"
+                />
+            </a>
+            <dl class="details-grid grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 overflow-hidden">
                 <dt>Desktop</dt>
                 <dd data-testid="desktop-session-desktop-type--{{ .Name }}">{{ .DesktopType }}</dd>
                 <dt>State</dt>
                 <dd data-testid="desktop-session-state--{{ .Name }}">{{ .State }}</dd>
                 <dt>Host</dt>
-                <dd data-testid="desktop-session-host--{{ .Name }}"><code class="text-fuchsia-700">{{ .Host }}</code></dd>
+                <dd
+                    data-testid="desktop-session-host--{{ .Name }}"
+                    title="{{ .Host }}"
+                >
+                    <code class="text-fuchsia-700">{{ .Host }}</code>
+                </dd>
                 <dt>Started</dt>
                 <dd data-testid="desktop-session-start-time--{{ .Name }}">{{ .StartTimeText }}</dd>
             </dl>


### PR DESCRIPTION
The images are shown at a fixed height and max width. If the image is wider than allowed at the fixed height, it is centered and clipped.

<img width="1000" height="599" alt="image" src="https://github.com/user-attachments/assets/bdff1979-2501-4f7f-a425-bd11fb596516" />

I've also double checked that images are correctly captured on a "barley-a-cluster" cluster running on garycloud.  I think the setup their is closer to the setup we need to support than our laptops.

Closes #158 