### PR TITLE
Add `webify` command

### DIFF
--- a/flight-core/pidfile/pidfile.go
+++ b/flight-core/pidfile/pidfile.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"syscall"
+
+	"github.com/concertim/flight-user-suite/flight/process"
 )
 
 // Read the PID file at path. Return the PID contained in the file if it
@@ -23,12 +24,7 @@ func Read(path string) (int, error) {
 	if pid == 0 {
 		return 0, fmt.Errorf("invalid content: pid=0")
 	}
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		return 0, nil
-	}
-	err = process.Signal(syscall.Signal(0))
-	if err != nil {
+	if !process.IsRunning(pid) {
 		return 0, nil
 	}
 	return pid, nil

--- a/flight-core/process/response.go
+++ b/flight-core/process/response.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"syscall"
 )
 
 type Response struct {
@@ -34,4 +35,13 @@ func (response *Response) WriteToParentFD() error {
 		responseFile.Close()
 	}
 	return nil
+}
+
+func IsRunning(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = process.Signal(syscall.Signal(0))
+	return err == nil
 }

--- a/flight-desktop/main.go
+++ b/flight-desktop/main.go
@@ -114,6 +114,7 @@ func main() {
 			listSessionsCommand(),
 			showSessionCommand(),
 			showSessionLogsCommand(),
+			webifySessionCommand(),
 			killSessionCommand(),
 			cleanSessionCommand(),
 		},

--- a/flight-desktop/session.go
+++ b/flight-desktop/session.go
@@ -20,6 +20,7 @@ import (
 
 	"charm.land/log/v2"
 	"github.com/adrg/xdg"
+	"github.com/concertim/flight-user-suite/flight/process"
 	"gopkg.in/yaml.v3"
 )
 
@@ -124,21 +125,10 @@ func (s *Session) Start(ctx context.Context) error {
 		s.cleanup()
 		return fmt.Errorf("staring VNC server: %w", err)
 	}
-	if err := s.startWebsockify(ctx); err != nil {
-		// Don't return an error here. The session will still be available over
-		// a standard VNC viewer.
-		log.Debug("Failed to start websockify process", "err", err)
-	}
-	if err := s.startGrabber(ctx); err != nil {
-		// Don't return an error here. This session just won't have screenshot
-		// capture enabled.
-		log.Debug("Failed to start screenshot grabber script", "err", err)
-	}
-	if err := s.startCleaner(ctx); err != nil {
-		// Don't return an error here, as we still want to save the session and
-		// recovering from this error is possible by manually running the clean
-		// command.
-		log.Debug("Failed to start cleaner script", "err", err)
+	if err := s.startWebAccessSupport(ctx); err != nil {
+		// Don't return. The session will still be available over a standard
+		// VNC viewer, and the user can run `webify` to recover.
+		log.Debug("Starting web support services", "err", err)
 	}
 	s.State = Active
 	s.IP = s.PrimaryIP().String()
@@ -147,6 +137,48 @@ func (s *Session) Start(ctx context.Context) error {
 		return fmt.Errorf("saving session: %w", err)
 	}
 	return nil
+}
+
+func (s *Session) Webify(ctx context.Context) error {
+	err := s.startWebAccessSupport(ctx)
+	if saveErr := s.Save(); saveErr != nil {
+		return fmt.Errorf("saving session: %w", saveErr)
+	}
+	if err != nil {
+		return fmt.Errorf("starting web access support: %w", err)
+	}
+	return nil
+}
+
+func (s *Session) startWebAccessSupport(ctx context.Context) error {
+	var websockifyErr error
+	var newProcessStarted bool
+
+	if s.WebsocketPid == 0 || !process.IsRunning(s.WebsocketPid) {
+		if err := s.startWebsockify(ctx); err != nil {
+			websockifyErr = fmt.Errorf("starting websockify process: %w", err)
+		} else {
+			newProcessStarted = true
+		}
+	}
+	if s.GrabberPid == 0 || !process.IsRunning(s.GrabberPid) {
+		if err := s.startGrabber(ctx); err != nil {
+			// Don't return an error here. This session just won't have screenshot
+			// capture enabled. It is still accessible in the browser with
+			// websocket support alone.
+			log.Debug("Failed to start screenshot grabber script", "err", err)
+		} else {
+			newProcessStarted = true
+		}
+	}
+	if newProcessStarted {
+		if err := s.startCleaner(ctx); err != nil {
+			// Don't return an error here. Recovering from this error is possible
+			// by manually running the `clean` command.
+			log.Debug("Failed to start cleaner script", "err", err)
+		}
+	}
+	return websockifyErr
 }
 
 func (s *Session) cleanup() {

--- a/flight-desktop/session_webify.go
+++ b/flight-desktop/session_webify.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"charm.land/log/v2"
+	"github.com/muesli/reflow/wordwrap"
+	"github.com/urfave/cli/v3"
+)
+
+func webifySessionCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "webify",
+		Usage:       "Start web access support for an active desktop session",
+		Description: wordwrap.String("Start required and optional web support programs for an active interactive desktop session.", maxTextWidth),
+		Category:    "Sessions",
+		// Flags:       []cli.Flag{formatFlag},
+		Arguments: []cli.Argument{
+			&cli.StringArg{Name: "name", UsageText: "<name>"},
+		},
+		Before:        assertArgPresent("name"),
+		ShellComplete: completeActiveSessionNames,
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			name := cmd.StringArg("name")
+			session, err := loadSession(name)
+			// if cmd.String("format") == "json" {
+			// 	return writeSessionJSON(session, err)
+			// }
+			if err != nil {
+				if err2 := session.RemoveSessionDir(); err2 != nil {
+					log.Debug("Removing session dir", "sessionDir", session.sessionDir(), "err", err2)
+				}
+				return err
+			}
+			switch session.ComputedState() {
+			case "active":
+				p := createPin("Starting web access support...")
+				cancel := p.Start(ctx)
+				defer cancel()
+				timer := time.After(1 * time.Second)
+				err = session.Webify(ctx)
+				<-timer
+				if err != nil {
+					p.Fail("Starting web access support failed")
+					return err
+				}
+				p.Stop("Web access support is ready!")
+				return nil
+
+			case "remote":
+				return fmt.Errorf("session %s is not local", session.Name)
+			default:
+				return fmt.Errorf("session %s is not active", session.Name)
+			}
+		},
+	}
+}

--- a/flight-desktop/session_webify.go
+++ b/flight-desktop/session_webify.go
@@ -14,7 +14,7 @@ func webifySessionCommand() *cli.Command {
 	return &cli.Command{
 		Name:        "webify",
 		Usage:       "Start web access support for an active desktop session",
-		Description: wordwrap.String("Start required and optional web support programs for an active interactive desktop session.", maxTextWidth),
+		Description: wordwrap.String("Start required and optional web support programs for an active interactive desktop session. Can be used to add web support to sessions that were started before web dependencies were installed.", maxTextWidth),
 		Category:    "Sessions",
 		// Flags:       []cli.Flag{formatFlag},
 		Arguments: []cli.Argument{

--- a/flight-desktop/testdata/golden/help.golden
+++ b/flight-desktop/testdata/golden/help.golden
@@ -17,12 +17,13 @@ COMMANDS:
      doctor  System health check
 
    Sessions:
-     start  Start an interactive desktop session
-     list   List interactive desktop sessions
-     show   Show information about a desktop session
-     logs   Show desktop session logs
-     kill   Terminate an interactive desktop session
-     clean  Clean up one or more exited or broken desktop sessions
+     start   Start an interactive desktop session
+     list    List interactive desktop sessions
+     show    Show information about a desktop session
+     logs    Show desktop session logs
+     webify  Start web access support for an active desktop session
+     kill    Terminate an interactive desktop session
+     clean   Clean up one or more exited or broken desktop sessions
 
 GLOBAL OPTIONS:
    --log-level LEVEL  set the log LEVEL (debug, info, warn, error, fatal). Default: warn


### PR DESCRIPTION
This PR adds a `webify` command to `flight-desktop`.

This allows the web support services for older sessions to be manually started. No attempt has been made to have web suite automate this process.  Whilst that would be really useful, it is not as straight forward as implementing the `webify` command.

The `webify` command starts the websockify process, the screenshot grabber script and the cleaner script.  A check is made around websockify and screenshot grabber to ensure that they are not started if already running. If
either websockify or grabber are started a new cleaner script is started.

If a new cleaner script is started, we probably ought to kill the old cleaner script. However, there is a maximum of three cleaner scripts running per session, It spends most of its time sleeping and having multiple run at once cannot interfere with each other.

### Future enhancements

* Web suite should automatically run the `webify` command when needed.  Perhaps, the desktop index page, could check a new attribute `IsWebified` on each session and run `webify` for each session that has not been webified.  `IsWebified` would be true if the session has both a running websockify and grabber process and false otherwise.

Closes #159 