### PR TITLE
Add cache buster to screenshots on page load

### DIFF
--- a/flight-web-suite/assets/javascript/controllers/refresh_controller.js
+++ b/flight-web-suite/assets/javascript/controllers/refresh_controller.js
@@ -4,19 +4,33 @@ import { Controller } from "@hotwired/stimulus"
 //
 // Connects to data-controller="refresh"
 export default class extends Controller {
-  static values = { interval: { type: Number, default: 60 * 1000 } }
+  static values = {
+    interval: { type: Number, default: 60 * 1000 },
+    src: String,
+  }
+
+  initialize() {
+    this.refresh = this.refresh.bind(this)
+  }
 
   connect() {
-    this.initialSrc = this.element.src
-    this.intervalId = setInterval(this.refresh.bind(this), this.intervalValue)
+    this.intervalId = setInterval(this.refresh, this.intervalValue)
   }
 
   disconnect() {
     clearInterval(this.intervalId)
   }
 
+  srcValueChanged() {
+    const initial = this.element.src == null || this.element.src == ""
+    if (initial && this.srcValue != null) {
+      this.element.src = this.srcValue
+    }
+    setTimeout(this.refresh, 250)
+  }
+
   refresh() {
     const cacheBuster = Date.now()
-    this.element.src = `${this.initialSrc}?t=${cacheBuster}`
+    this.element.src = `${this.srcValue}?t=${cacheBuster}`
   }
 }

--- a/flight-web-suite/assets/javascript/controllers/refresh_controller.js
+++ b/flight-web-suite/assets/javascript/controllers/refresh_controller.js
@@ -22,6 +22,9 @@ export default class extends Controller {
   }
 
   srcValueChanged() {
+    // Jump through hoops to get a, hopefully cached, image displayed ASAP and
+    // then replace it with an updated image.  Using a cached image (instead of
+    // whitespace) results in less visual "flicker".
     const initial = this.element.src == null || this.element.src == ""
     if (initial && this.srcValue != null) {
       this.element.src = this.srcValue

--- a/flight-web-suite/views/pages/desktop/index.gohtml
+++ b/flight-web-suite/views/pages/desktop/index.gohtml
@@ -63,8 +63,8 @@
             >
                 <img
                     class="h-full max-w-fit"
-                    src="/desktop/{{ .Name }}/screenshot"
                     data-controller="refresh"
+                    data-refresh-src-value="/desktop/{{ .Name }}/screenshot"
                     data-refresh-interval-value="{{300000}}"
                 />
             </a>

--- a/flight-web-suite/views/pages/desktop/show.gohtml
+++ b/flight-web-suite/views/pages/desktop/show.gohtml
@@ -62,7 +62,12 @@
 
     <div class="h-[calc(100%_-_var(--spacing)_*_10)]">
         <div class="h-full min-h-full w-full min-w-full relative cursor-pointer" data-novnc-target="previewImage" data-action="click->novnc#reconnect">
-            <img class="m-auto opacity-60 saturate-30" src="/desktop/{{ .Name }}/screenshot" data-controller="refresh" data-refresh-interval-value="{{300000}}" />
+            <img
+                class="m-auto opacity-60 saturate-30"
+                data-controller="refresh"
+                data-refresh-src-value="/desktop/{{ .Name }}/screenshot"
+                data-refresh-interval-value="{{300000}}"
+            />
             <div class="absolute top-0 bottom-0 left-0 right-0 flex items-center justify-center">
                 <span class="px-6 py-2 bg-white rounded-full font-semibold text-xl" data-novnc-target="status">Connecting...</span>
             </div>


### PR DESCRIPTION
Previously, the cache buster was only added once the screenshot was refreshed after 5 minutes.  Until then it would potentially use a cached value which may well have been the placeholder image.

Fixes #177 