### PR TITLE
Support custom screen geometry

### DIFF
--- a/flight-web-suite/assets/javascript/application.js
+++ b/flight-web-suite/assets/javascript/application.js
@@ -6,12 +6,14 @@ import "./dropdown";
 // below.
 import DisableWithController from "./controllers/disable_with_controller.js"
 import FullscreenController from "./controllers/fullscreen_controller.js"
+import GeometryInputsController from "./controllers/geometry_inputs_controller.js"
 import MenuToggleController from "./controllers/menu_toggle_controller.js"
 import NovncController from "./controllers/novnc_controller"
 import RefreshController from "./controllers/refresh_controller.js"
 
 window.Stimulus = Application.start()
 Stimulus.register("disable-with", DisableWithController)
+Stimulus.register("geometry-inputs", GeometryInputsController)
 Stimulus.register("novnc", NovncController)
 Stimulus.register("fullscreen", FullscreenController)
 Stimulus.register("menu-toggle", MenuToggleController)

--- a/flight-web-suite/assets/javascript/controllers/disable_with_controller.js
+++ b/flight-web-suite/assets/javascript/controllers/disable_with_controller.js
@@ -4,22 +4,28 @@ export default class extends Controller {
   connect() {
     const button = this.element
     if (button.dataset.disableWith) {
-      button.addEventListener('click', () => {
 
-        if (!button.form || button.form.checkValidity()) {
-          // Delay actually disabling the button until the form submission has
-          // gone through.
-          setTimeout(
-            () => { button.disabled = true },
-            1
-          )
+      if (button.form) {
+        button.form.addEventListener('submit', () => this.disable(button))
+      }
+      else {
+        button.addEventListener('click', () => this.disable(button))
+      }
 
-          button.innerText = button.dataset.disableWith
-          if (button.dataset.disableWithClass) {
-            button.classList.add(button.dataset.disableWithClass)
-          }
-        }
-      })
+    }
+  }
+
+  disable(button) {
+    // Delay actually disabling the button until the form submission has
+    // gone through.
+    setTimeout(
+      () => { button.disabled = true },
+      1
+    )
+
+    button.innerText = button.dataset.disableWith
+    if (button.dataset.disableWithClass) {
+      button.classList.add(button.dataset.disableWithClass)
     }
   }
 }

--- a/flight-web-suite/assets/javascript/controllers/disable_with_controller.js
+++ b/flight-web-suite/assets/javascript/controllers/disable_with_controller.js
@@ -5,16 +5,19 @@ export default class extends Controller {
     const button = this.element
     if (button.dataset.disableWith) {
       button.addEventListener('click', () => {
-        // Delay actually disabling the button until the form submission has
-        // gone through.
-        setTimeout(
-          () => { button.disabled = true },
-          1
-        )
 
-        button.innerText = button.dataset.disableWith
-        if (button.dataset.disableWithClass) {
-          button.classList.add(button.dataset.disableWithClass)
+        if (!button.form || button.form.checkValidity()) {
+          // Delay actually disabling the button until the form submission has
+          // gone through.
+          setTimeout(
+            () => { button.disabled = true },
+            1
+          )
+
+          button.innerText = button.dataset.disableWith
+          if (button.dataset.disableWithClass) {
+            button.classList.add(button.dataset.disableWithClass)
+          }
         }
       })
     }

--- a/flight-web-suite/assets/javascript/controllers/geometry_inputs_controller.js
+++ b/flight-web-suite/assets/javascript/controllers/geometry_inputs_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "geometrySelect", "customFields" ]
+  static values = { showCustom: { type: Boolean, default: false } }
+
+  initialize() {
+    this.updateVisibility = this.updateVisibility.bind(this)
+  }
+
+  geometrySelectTargetConnected(elem) {
+    elem.addEventListener('change', this.updateVisibility);
+  }
+
+  geometrySelectTargetDisconnected(elem) {
+    elem.removeEventListener('change', this.updateVisibility);
+  }
+
+  updateVisibility() {
+    this.showCustomValue = this.geometrySelectTarget.value == "custom";
+  }
+
+  showCustomValueChanged(newValue) {
+    if (newValue) {
+      this.customFieldsTarget.classList.remove('hidden')
+    }
+    else {
+      this.customFieldsTarget.classList.add('hidden')
+    }
+  }
+}

--- a/flight-web-suite/assets/javascript/controllers/geometry_inputs_controller.js
+++ b/flight-web-suite/assets/javascript/controllers/geometry_inputs_controller.js
@@ -10,6 +10,11 @@ export default class extends Controller {
 
   geometrySelectTargetConnected(elem) {
     elem.addEventListener('change', this.updateVisibility);
+    this.updateVisibility()
+  }
+
+  customFieldsTargetConnected() {
+    this.updateVisibility()
   }
 
   geometrySelectTargetDisconnected(elem) {
@@ -17,7 +22,9 @@ export default class extends Controller {
   }
 
   updateVisibility() {
-    this.showCustomValue = this.geometrySelectTarget.value == "custom";
+    if (this.hasGeometrySelectTarget) {
+      this.showCustomValue = this.geometrySelectTarget.value == "custom";
+    }
   }
 
   showCustomValueChanged(newValue) {

--- a/flight-web-suite/assets/javascript/controllers/geometry_inputs_controller.js
+++ b/flight-web-suite/assets/javascript/controllers/geometry_inputs_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = [ "geometrySelect", "customFields" ]
+  static targets = [ "geometrySelect", "customFields", "input" ]
   static values = { showCustom: { type: Boolean, default: false } }
 
   initialize() {
@@ -26,6 +26,9 @@ export default class extends Controller {
     }
     else {
       this.customFieldsTarget.classList.add('hidden')
+    }
+    for (const ip of this.inputTargets) {
+      ip.required = newValue
     }
   }
 }

--- a/flight-web-suite/desktop_launch.go
+++ b/flight-web-suite/desktop_launch.go
@@ -25,8 +25,17 @@ type desktopLaunchFormData struct {
 	DesktopType string
 	Name        string
 	Geometry    string
+	CustomX     int
+	CustomY     int
 	Errors      desktopLaunchFieldErrors
 	Alert       string
+}
+
+func (data *desktopLaunchFormData) getComputedGeometry() string {
+	if data.Geometry == "custom" {
+		return fmt.Sprintf("%dx%d", data.CustomX, data.CustomY)
+	}
+	return data.Geometry
 }
 
 var desktopGeometryOptions = []desktopGeometryOption{
@@ -36,6 +45,7 @@ var desktopGeometryOptions = []desktopGeometryOption{
 	{Value: "1280x1024", Label: "1280 x 1024"},
 	{Value: "1920x1080", Label: "1920 x 1080"},
 	{Value: "1600x1200", Label: "1600 x 1200"},
+	{Value: "custom", Label: "Custom"},
 }
 
 func newDesktopSessionHandler(c *echo.Context) error {
@@ -71,11 +81,18 @@ func createDesktopSessionHandler(c *echo.Context) error {
 		return err
 	}
 
+	customX, _ := echo.FormValue[int](c, "custom_x")
+	customY, _ := echo.FormValue[int](c, "custom_y")
+
 	form := desktopLaunchFormData{
 		DesktopType: c.FormValue("desktop_type"),
 		Name:        c.FormValue("name"),
 		Geometry:    c.FormValue("geometry"),
+		CustomX:     customX,
+		CustomY:     customY,
 	}
+
+	fmt.Printf("%+v", form)
 
 	desktopTypes, err := desktop.AvailCommand(c.Request().Context(), env, CurrentUserName(c))
 	if err != nil {
@@ -87,7 +104,7 @@ func createDesktopSessionHandler(c *echo.Context) error {
 		response, err := desktop.StartCommand(c.Request().Context(), env, CurrentUserName(c), desktop.StartInput{
 			DesktopType: form.DesktopType,
 			Name:        form.Name,
-			Geometry:    form.Geometry,
+			Geometry:    form.getComputedGeometry(),
 		})
 		if err != nil {
 			return err
@@ -129,7 +146,7 @@ func validateDesktopLaunchForm(desktopTypes []*desktop.Type, form *desktopLaunch
 	if !hasDesktopType(desktopTypes, form.DesktopType) {
 		form.Errors.DesktopType = "Select an available desktop type."
 	}
-	if !hasDesktopGeometry(form.Geometry) {
+	if !hasDesktopGeometry(form.Geometry, form.CustomX, form.CustomY) {
 		form.Errors.Geometry = "Select a supported geometry."
 	}
 }
@@ -218,9 +235,12 @@ func hasDesktopType(desktopTypes []*desktop.Type, id string) bool {
 	return false
 }
 
-func hasDesktopGeometry(geometry string) bool {
+func hasDesktopGeometry(geometry string, customX, customY int) bool {
 	for _, option := range desktopGeometryOptions {
 		if option.Value == geometry {
+			if geometry == "custom" {
+				return customX > 0 && customY > 0
+			}
 			return true
 		}
 	}

--- a/flight-web-suite/desktop_launch.go
+++ b/flight-web-suite/desktop_launch.go
@@ -30,8 +30,12 @@ type desktopLaunchFormData struct {
 }
 
 var desktopGeometryOptions = []desktopGeometryOption{
+	{Value: "1280x720", Label: "1280 x 720"},
 	{Value: "1024x768", Label: "1024 x 768 (default)", Default: true},
+	{Value: "1600x900", Label: "1600 x 900"},
 	{Value: "1280x1024", Label: "1280 x 1024"},
+	{Value: "1920x1080", Label: "1920 x 1080"},
+	{Value: "1600x1200", Label: "1600 x 1200"},
 }
 
 func newDesktopSessionHandler(c *echo.Context) error {

--- a/flight-web-suite/desktop_launch.go
+++ b/flight-web-suite/desktop_launch.go
@@ -129,7 +129,12 @@ func createDesktopSessionHandler(c *echo.Context) error {
 	}
 	sess.AddFlash(alert, "alert")
 	SaveSession(c, sess)
-	return renderDesktopLaunchPage(c, http.StatusUnprocessableEntity, desktopTypes, nil, form)
+	dependencyReport, err := desktop.DoctorCommand(c.Request().Context(), env, CurrentUserName(c))
+	if err != nil {
+		return err
+	}
+
+	return renderDesktopLaunchPage(c, http.StatusUnprocessableEntity, desktopTypes, dependencyReport, form)
 }
 
 func requireDesktopToolEnabled() error {
@@ -174,17 +179,17 @@ func renderDesktopLaunchPage(c *echo.Context, status int, desktopTypes []*deskto
 	coreDependenciesOK := false
 	missingDependencies := []string{}
 	if doctorReport != nil {
-	    coreDependenciesOK = doctorReport.OK
-	    for _, dep := range doctorReport.Checks {
-	        if dep.Found != true {
-	            missingDependencies = append(missingDependencies, dep.Description)
-	        }
-	    }
+		coreDependenciesOK = doctorReport.OK
+		for _, dep := range doctorReport.Checks {
+			if dep.Found != true {
+				missingDependencies = append(missingDependencies, dep.Description)
+			}
+		}
 	}
 
 	data := map[string]any{
-	    "CoreDependenciesOK":       coreDependenciesOK,
-	    "MissingDependencies":      missingDependencies,
+		"CoreDependenciesOK":       coreDependenciesOK,
+		"MissingDependencies":      missingDependencies,
 		"DesktopTypes":             desktopTypes,
 		"NumAvailableDesktopTypes": numAvailableDesktopTypes(desktopTypes),
 		"GeometryOptions":          desktopGeometryOptions,

--- a/flight-web-suite/desktop_launch.go
+++ b/flight-web-suite/desktop_launch.go
@@ -92,8 +92,6 @@ func createDesktopSessionHandler(c *echo.Context) error {
 		CustomY:     customY,
 	}
 
-	fmt.Printf("%+v", form)
-
 	desktopTypes, err := desktop.AvailCommand(c.Request().Context(), env, CurrentUserName(c))
 	if err != nil {
 		return err

--- a/flight-web-suite/desktop_launch_functional_test.go
+++ b/flight-web-suite/desktop_launch_functional_test.go
@@ -254,6 +254,15 @@ JSON
 func TestCreateDesktopSessionFailureRedisplaysFormWithPreservedValues(t *testing.T) {
 	currentUser := currentUserForTest(t)
 	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+if [ "$1" = "doctor" ]; then
+cat <<'JSON'
+{
+	"ok": true,
+	"checks": []
+}
+JSON
+exit 0
+fi
 if [ "$1" = "avail" ]; then
 cat <<'JSON'
 [
@@ -313,6 +322,15 @@ exit 1
 func TestCreateDesktopSessionFailureWithoutProvidedNameDoesNotExposeGeneratedName(t *testing.T) {
 	currentUser := currentUserForTest(t)
 	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+if [ "$1" = "doctor" ]; then
+cat <<'JSON'
+{
+	"ok": true,
+	"checks": []
+}
+JSON
+exit 0
+fi
 if [ "$1" = "avail" ]; then
 cat <<'JSON'
 [
@@ -363,6 +381,15 @@ exit 1
 func TestCreateDesktopSessionInvalidNameShowsUserFriendlyMessage(t *testing.T) {
 	currentUser := currentUserForTest(t)
 	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+if [ "$1" = "doctor" ]; then
+cat <<'JSON'
+{
+	"ok": true,
+	"checks": []
+}
+JSON
+exit 0
+fi
 if [ "$1" = "avail" ]; then
 cat <<'JSON'
 [
@@ -419,6 +446,15 @@ func TestCreateDesktopSessionWithInvalidGeometryShowsInlineErrorWithoutInvokingS
 	argsFile := filepath.Join(t.TempDir(), "desktop-args.txt")
 	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
 printf '%s\n' "$@" >> "`+argsFile+`"
+if [ "$1" = "doctor" ]; then
+cat <<'JSON'
+{
+	"ok": true,
+	"checks": []
+}
+JSON
+exit 0
+fi
 cat <<'JSON'
 [
   {
@@ -453,8 +489,8 @@ JSON
 	if err != nil {
 		t.Fatalf("failed to read command args fixture: %v", err)
 	}
-	if got := strings.TrimSpace(string(data)); got != "avail\n--format\njson" {
-		t.Fatalf("expected only avail command args, got %q", got)
+	if got := strings.TrimSpace(string(data)); got != "avail\n--format\njson\ndoctor\n--format\njson" {
+		t.Fatalf("expected only avail and doctor commands, got %q", got)
 	}
 }
 
@@ -463,6 +499,15 @@ func TestCreateDesktopSessionWithInvalidDesktopTypeShowsInlineErrorWithoutInvoki
 	argsFile := filepath.Join(t.TempDir(), "desktop-args.txt")
 	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
 printf '%s\n' "$@" >> "`+argsFile+`"
+if [ "$1" = "doctor" ]; then
+cat <<'JSON'
+{
+	"ok": true,
+	"checks": []
+}
+JSON
+exit 0
+fi
 cat <<'JSON'
 [
   {
@@ -498,7 +543,7 @@ JSON
 	if err != nil {
 		t.Fatalf("failed to read command args fixture: %v", err)
 	}
-	if got := strings.TrimSpace(string(data)); got != "avail\n--format\njson" {
-		t.Fatalf("expected only avail command args, got %q", got)
+	if got := strings.TrimSpace(string(data)); got != "avail\n--format\njson\ndoctor\n--format\njson" {
+		t.Fatalf("expected only avail and doctor commands, got %q", got)
 	}
 }

--- a/flight-web-suite/desktop_launch_integration_test.go
+++ b/flight-web-suite/desktop_launch_integration_test.go
@@ -60,6 +60,15 @@ func TestCreateDesktopSessionFailureAddsFlashAndRedisplaysForm(t *testing.T) {
 	currentUser := currentUserForTest(t)
 	setAuthenticatorPathForTest(t, filepath.Join("testdata", "authenticator_success.sh"))
 	setFlightRootForDesktopTest(t, desktopToolFixture(t, 0o755, `#!/bin/sh
+if [ "$1" = "doctor" ]; then
+cat <<'JSON'
+{
+	"ok": true,
+	"checks": []
+}
+JSON
+exit 0
+fi
 if [ "$1" = "avail" ]; then
 cat <<'JSON'
 [

--- a/flight-web-suite/views/pages/desktop/new.gohtml
+++ b/flight-web-suite/views/pages/desktop/new.gohtml
@@ -156,6 +156,7 @@
                         name="custom_x"
                         placeholder="Width"
                         type="number"
+                        value="{{ .Form.CustomX }}"
                     />
                         x
                     <input
@@ -165,6 +166,7 @@
                         name="custom_y"
                         placeholder="Height"
                         type="number"
+                        value="{{ .Form.CustomY }}"
                     />
                 </div>
                 {{if .Form.Errors.Geometry}}

--- a/flight-web-suite/views/pages/desktop/new.gohtml
+++ b/flight-web-suite/views/pages/desktop/new.gohtml
@@ -121,7 +121,7 @@
                     <p class="mt-2 text-sm text-red-700" data-testid="desktop-launch-name-error">{{ .Form.Errors.Name }}</p>
                 {{end}}
             </div>
-            <div class="flex flex-col gap-y-2 items-center text-field">
+            <div class="flex flex-col gap-y-2 items-center text-field" data-controller="geometry-inputs">
                 <label for="desktop-launch-geometry">
                     Select your desktop resolution
                 </label>
@@ -130,6 +130,7 @@
                     name="geometry"
                     class="custom-select"
                     data-testid="desktop-launch-geometry"
+                    data-geometry-inputs-target="geometrySelect"
                 >
                     {{range .GeometryOptions}}
                         <option
@@ -142,6 +143,7 @@
                 <div
                     class="flex gap-2 items-center"
                     id="custom-resolution-fields"
+                    data-geometry-inputs-target="customFields"
                 >
                     <label for="custom_resolution_x">
                         Custom resolution:

--- a/flight-web-suite/views/pages/desktop/new.gohtml
+++ b/flight-web-suite/views/pages/desktop/new.gohtml
@@ -149,20 +149,22 @@
                         Custom resolution:
                     </label>
                     <input
-                        id="custom_resolution_x"
-                        name="custom_x"
                         class="max-w-32"
-                        type="number"
-                        min="0"
                         data-geometry-inputs-target="input"
+                        id="custom_resolution_x"
+                        min="0"
+                        name="custom_x"
+                        placeholder="Width"
+                        type="number"
                     />
                         x
                     <input
-                        name="custom_y"
                         class="max-w-32"
-                        type="number"
-                        min="0"
                         data-geometry-inputs-target="input"
+                        min="0"
+                        name="custom_y"
+                        placeholder="Height"
+                        type="number"
                     />
                 </div>
                 {{if .Form.Errors.Geometry}}

--- a/flight-web-suite/views/pages/desktop/new.gohtml
+++ b/flight-web-suite/views/pages/desktop/new.gohtml
@@ -139,6 +139,28 @@
                         >{{ .Label }}</option>
                     {{end}}
                 </select>
+                <div
+                    class="flex gap-2 items-center"
+                    id="custom-resolution-fields"
+                >
+                    <label for="custom_resolution_x">
+                        Custom resolution:
+                    </label>
+                    <input
+                        id="custom_resolution_x"
+                        name="custom_x"
+                        class="max-w-32"
+                        type="number"
+                        min="0"
+                    />
+                    x
+                    <input
+                        name="custom_y"
+                        class="max-w-32"
+                        type="number"
+                        min="0"
+                    />
+                </div>
                 {{if .Form.Errors.Geometry}}
                     <p class="mt-2 text-sm text-red-700" data-testid="desktop-launch-geometry-error">{{ .Form.Errors.Geometry }}</p>
                 {{end}}

--- a/flight-web-suite/views/pages/desktop/new.gohtml
+++ b/flight-web-suite/views/pages/desktop/new.gohtml
@@ -154,13 +154,15 @@
                         class="max-w-32"
                         type="number"
                         min="0"
+                        data-geometry-inputs-target="input"
                     />
-                    x
+                        x
                     <input
                         name="custom_y"
                         class="max-w-32"
                         type="number"
                         min="0"
+                        data-geometry-inputs-target="input"
                     />
                 </div>
                 {{if .Form.Errors.Geometry}}


### PR DESCRIPTION
This PR adds the ability to specify custom screen geometry to the desktop launch form. It also adds several more hard-coded geometry options to the dropdown menu.

<img width="922" height="762" alt="image" src="https://github.com/user-attachments/assets/dd858551-8d17-496d-8428-572061cc3f7d" />

The custom resolution fields are only shown when "custom" is selected from the dropdown; they are also marked as `required` in that scenario.

`disable_with_controller` has become smarter about disabling a button within a form; it waits for the form's (post-validation) `submit` event before disabling the button. Otherwise, trying to submit an invalid form would disable the button with no way of un-disabling it once the validation errors had been corrected.

Resolves #148.