### PR TITLE
Remove false positive admin checks

### DIFF
--- a/flight-core/opt/flight/usr/share/doc/flight-user-suite/01-about-flight-user-suite.md
+++ b/flight-core/opt/flight/usr/share/doc/flight-user-suite/01-about-flight-user-suite.md
@@ -60,5 +60,5 @@ running `flight howto list` in an active flight environment.
 
 Flight User Suite considers a user an admin if they:
 - Are `root`
-- Have passwordless sudo (which includes if sudo is currently passwordless due
-  to having a cached password)
+- Have passwordless sudo access to run `flight` (which includes if sudo is
+  currently passwordless due to having a cached password)

--- a/flight-core/userroles/userroles.go
+++ b/flight-core/userroles/userroles.go
@@ -17,19 +17,50 @@ import (
 // and false otherwise.
 //
 // "Considered an admin" is defined as: has password-less `sudo` access to run
-// `/bin/bash`.  It would be better to check if they have password-less `sudo`
-// access to run `flight`, but the path to `flight` can change a lot depending
-// on which environment we're in - production, development etc..  In practice
-// checking `/bin/bash` is much easier and likely to provide the same result.
+// the same `flight` executable that AsRoot will re-exec.
 func IsAdmin() bool {
 	if os.Geteuid() == 0 {
 		return true
 	}
-	exe := exec.Command("sudo", "-ln", "/bin/bash")
+	path, err := flightCommandPath()
+	if err != nil {
+		return false
+	}
+	exe := exec.Command("sudo", "-ln", "--", path)
 	if err := exe.Run(); err != nil {
 		return false
 	}
 	return true
+}
+
+func flightCommandPath() (string, error) {
+	path, err := os.Executable()
+	if err == nil {
+		path, evalErr := filepath.EvalSymlinks(path)
+		if evalErr == nil {
+			return path, nil
+		}
+		return path, nil
+	}
+
+	// Fall back to resolving argv[0] for environments where os.Executable
+	// cannot determine the path.
+	if filepath.IsAbs(os.Args[0]) {
+		return os.Args[0], nil
+	}
+
+	path, err = exec.LookPath(os.Args[0])
+	if errors.Is(err, exec.ErrDot) {
+		dir, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("resolving flight command path: %w", err)
+		}
+		return filepath.Join(dir, path), nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("resolving flight command path: %w", err)
+	}
+	return path, nil
 }
 
 func AsRoot(wrapped cli.ActionFunc) cli.ActionFunc {
@@ -44,25 +75,10 @@ func AsRoot(wrapped cli.ActionFunc) cli.ActionFunc {
 			return fmt.Errorf("command '%s' not available to non-admin users", cmd.Name)
 		}
 
-		// Jump through hoops to re-exec with an absolute path. Handle the case
-		// where the binary is ran as `./opt/flight/bin/flight ...` as that is
-		// common in development.
-		var path string
-		if filepath.IsAbs(os.Args[0]) {
-			path = os.Args[0]
-		} else {
-			var err error
-			path, err = exec.LookPath(os.Args[0])
-			if errors.Is(err, exec.ErrDot) {
-				dir, err := os.Getwd()
-				if err != nil {
-					return fmt.Errorf("unexpected error trying to run as root: %w", err)
-				}
-				path = filepath.Join(dir, path)
-			} else if err != nil {
-				// This should not have happened.
-				return fmt.Errorf("unexpected error trying to run as root: %w", err)
-			}
+		path, err := flightCommandPath()
+		if err != nil {
+			// This should not have happened.
+			return fmt.Errorf("unexpected error trying to run as root: %w", err)
 		}
 
 		// Let's re-exec with sudo, preserving just enough of the environment

--- a/flight-core/userroles/userroles.go
+++ b/flight-core/userroles/userroles.go
@@ -16,12 +16,16 @@ import (
 // IsAdmin returns true if the user running the process is considered an admin
 // and false otherwise.
 //
-// Considered an admin is defined as: has password-less sudo access.
+// "Considered an admin" is defined as: has password-less `sudo` access to run
+// `/bin/bash`.  It would be better to check if they have password-less `sudo`
+// access to run `flight`, but the path to `flight` can change a lot depending
+// on which environment we're in - production, development etc..  In practice
+// checking `/bin/bash` is much easier and likely to provide the same result.
 func IsAdmin() bool {
 	if os.Geteuid() == 0 {
 		return true
 	}
-	exe := exec.Command("sudo", "-ln")
+	exe := exec.Command("sudo", "-ln", "/bin/bash")
 	if err := exe.Run(); err != nil {
 		return false
 	}


### PR DESCRIPTION
Admin check gives almost(?) zero false positives

When checking if a user should be considered an admin, we now consider if they have password-less `sudo` access to run `flight`, instead of any kind of password-less sudo.

A user could be setup with password-less `sudo` access to run a single specific command, but not general `sudo` access.  Checking against `flight` prevents that false positive.

We have to determine the absolute path to `flight` when actually running `sudo`, so we can use the same mechanism to determine the path to make the sudo check against.

This will work for production setups that grant specific sudo access, e.g., just to run `/opt/flight/bin/flight`; or for production setups that provide general sudo access to everything.

In development, it is a little more awkward, but still manageable. Password-less sudo access could be setup to run the binary in `dist`, e.g., `~/projects/flight-user-suite/dist/opt/flight/bin/flight`, which will then work nicely with web suite. Alternatively, if general sudo access is available, `go run` will detect the user as an admin.
