### PR TITLE
Prevent show page for non-webified desktop sessions

### DIFF
--- a/flight-desktop/session.go
+++ b/flight-desktop/session.go
@@ -139,6 +139,18 @@ func (s *Session) Start(ctx context.Context) error {
 	return nil
 }
 
+func (s Session) IsWebified() bool {
+	switch s.ComputedState() {
+	case "active":
+		return s.WebsocketPid != 0 && process.IsRunning(s.WebsocketPid)
+	case "remote":
+		// TODO: SSH to the machine its running on and check if its webified.
+		return true
+	default:
+		return false
+	}
+}
+
 func (s *Session) Webify(ctx context.Context) error {
 	err := s.startWebAccessSupport(ctx)
 	if saveErr := s.Save(); saveErr != nil {

--- a/flight-desktop/session_list.go
+++ b/flight-desktop/session_list.go
@@ -44,6 +44,7 @@ type listedSession struct {
 	State       sessionState `json:"state"`
 	Host        string       `json:"host"`
 	CreatedAt   string       `json:"created_at"`
+	IsWebified  bool         `json:"is_webified"`
 }
 
 func writeSessionsJSON(sessions []*Session) error {
@@ -55,6 +56,7 @@ func writeSessionsJSON(sessions []*Session) error {
 			State:       session.ComputedState(),
 			Host:        session.Metadata.Host,
 			CreatedAt:   session.CreatedAt.Format(time.RFC3339),
+			IsWebified:  session.IsWebified(),
 		})
 	}
 	enc := json.NewEncoder(os.Stdout)

--- a/flight-desktop/session_show.go
+++ b/flight-desktop/session_show.go
@@ -65,6 +65,7 @@ type shownSession struct {
 	Password       string       `json:"password"`
 	CreatedAt      string       `json:"created_at"`
 	ScreenshotPath string       `json:"screenshot_path"`
+	IsWebified     bool         `json:"is_webified"`
 }
 
 func writeSessionJSON(session *Session, loadErr error) error {
@@ -97,6 +98,7 @@ func writeSessionJSON(session *Session, loadErr error) error {
 		WebsocketPort:  session.GetWebsocketPort(),
 		CreatedAt:      session.CreatedAt.Format(time.RFC3339),
 		ScreenshotPath: session.ScreenshotPath(),
+		IsWebified:     session.IsWebified(),
 	}
 	response := showResponse{
 		Success: true,

--- a/flight-web-suite/desktop/list.go
+++ b/flight-web-suite/desktop/list.go
@@ -20,6 +20,7 @@ type Session struct {
 	Password       string    `json:"password,omitempty"`
 	CreatedAt      time.Time `json:"created_at"`
 	ScreenshotPath string    `json:"screenshot_path"`
+	IsWebified     bool      `json:"is_webified"`
 }
 
 func ListCommand(ctx context.Context, env configenv.Env, username string) ([]*Session, error) {

--- a/flight-web-suite/desktop_launch_integration_test.go
+++ b/flight-web-suite/desktop_launch_integration_test.go
@@ -29,6 +29,19 @@ cat <<'JSON'
 JSON
   exit 0
 fi
+if [ "$1" = "show" ]; then
+cat <<'JSON'
+{
+  "success": true,
+  "session": {
+	  "name": "named-session",
+	  "state": "active",
+	  "is_webified": true
+  }
+}
+JSON
+  exit 0
+fi
 cat <<'JSON'
 {
   "success": true,

--- a/flight-web-suite/desktop_sessions.go
+++ b/flight-web-suite/desktop_sessions.go
@@ -15,6 +15,7 @@ type desktopSessionCard struct {
 	DesktopType          string
 	State                string
 	Host                 string
+	IsWebified           bool
 	StartTimeText        string
 	ActionLabel          string
 	ActionTitle          string
@@ -72,6 +73,12 @@ func showDesktopSessionHandler(c *echo.Context) error {
 		} else {
 			sess.AddFlash(fmt.Sprintf("Unexpected error finding desktop session: %s", response.Error), "alert")
 		}
+		SaveSession(c, sess)
+		return c.Redirect(http.StatusSeeOther, "/desktop")
+	}
+
+	if !response.Session.IsWebified {
+		sess.AddFlash("Desktop session cannot be accessed via Flight Web Suite", "alert")
 		SaveSession(c, sess)
 		return c.Redirect(http.StatusSeeOther, "/desktop")
 	}
@@ -165,6 +172,7 @@ func buildDesktopSessionCards(sessions []*desktop.Session) []desktopSessionCard 
 			DesktopType:          session.DesktopType,
 			State:                session.State,
 			Host:                 session.Host,
+			IsWebified:           session.IsWebified,
 			StartTimeText:        session.CreatedAt.Format("Mon 2 Jan 2006 15:04"),
 			ActionLabel:          actionLabel,
 			ActionTitle:          actionTitle,

--- a/flight-web-suite/desktop_sessions_functional_test.go
+++ b/flight-web-suite/desktop_sessions_functional_test.go
@@ -29,7 +29,8 @@ cat <<'JSON'
     "desktop_type": "Gnome",
     "state": "active",
     "host": "host-a",
-    "created_at": "2026-04-20T10:00:00Z"
+    "created_at": "2026-04-20T10:00:00Z",
+		"is_webified": true
   },
   {
     "name": "beta",

--- a/flight-web-suite/views/pages/desktop/index.gohtml
+++ b/flight-web-suite/views/pages/desktop/index.gohtml
@@ -76,7 +76,14 @@
                 <dt>Desktop</dt>
                 <dd data-testid="desktop-session-desktop-type--{{ .Name }}">{{ .DesktopType }}</dd>
                 <dt>State</dt>
-                <dd data-testid="desktop-session-state--{{ .Name }}">{{ .State }}</dd>
+                <dd data-testid="desktop-session-state--{{ .Name }}">
+                    {{ .State }}
+                    {{ if not .IsWebified }}
+                        <span title="Run `flight desktop webify {{ .Name }}` on the server to make this session available">
+                            (not available in Flight Web Suite)
+                        </span>
+                    {{ end }}
+                </dd>
                 <dt>Host</dt>
                 <dd
                     data-testid="desktop-session-host--{{ .Name }}"

--- a/flight-web-suite/views/pages/desktop/index.gohtml
+++ b/flight-web-suite/views/pages/desktop/index.gohtml
@@ -59,7 +59,11 @@
             </div>
             <a
                 class="mb-4 flex justify-center h-46 overflow-clip"
+                {{ if .IsWebified }}
                 href="/desktop/{{ .Name }}"
+                {{ else }}
+                disabled="disabled"
+                {{ end }}
             >
                 <img
                     class="h-full max-w-fit"
@@ -83,7 +87,7 @@
                 <dt>Started</dt>
                 <dd data-testid="desktop-session-start-time--{{ .Name }}">{{ .StartTimeText }}</dd>
             </dl>
-            {{ if or (eq .State "active") (eq .State "remote") }}
+            {{ if and .IsWebified (or (eq .State "active") (eq .State "remote")) }}
                 <a class="btn btn-outline btn-sm block !mb-0 mt-3 w-full text-center" href="/desktop/{{ .Name }}">View</a>
             {{ end }}
         </div>

--- a/flight-web-suite/views/pages/desktop/index.gohtml
+++ b/flight-web-suite/views/pages/desktop/index.gohtml
@@ -78,7 +78,7 @@
                 <dt>State</dt>
                 <dd data-testid="desktop-session-state--{{ .Name }}">
                     {{ .State }}
-                    {{ if not .IsWebified }}
+                    {{ if and (not .IsWebified) (or (eq .State "active") (eq .State "remote")) }}
                         <span title="Run `flight desktop webify {{ .Name }}` on the server to make this session available">
                             (not available in Flight Web Suite)
                         </span>


### PR DESCRIPTION
When generating JSON list of desktop sessions, include `is_webified` attribute.  This is true if the session is remote; if it is active and websockets is running; false otherwise.

The list page only links to show page for sessions that are webified.

When generating JSON for single desktop session, include `is_webified`.

The show page redirects to the list page if the session is not webified.

Resolves #186 