### PR TITLE
Add `web doctor` command to check web suite dependencies

### DIFF
--- a/flight-core/doctor/doctor.go
+++ b/flight-core/doctor/doctor.go
@@ -1,0 +1,210 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/yarlson/pin"
+)
+
+const (
+	TypeExecutable = "exe"
+	TypeDirectory  = "dir"
+)
+
+var SpinnerDelay = 1 * time.Second
+
+type Dependency struct {
+	Type           string   `yaml:"type"`
+	Description    string   `yaml:"description"`
+	Optional       bool     `yaml:"optional"`
+	Paths          []string `yaml:"paths"`
+	FailureMessage string   `yaml:"failure_message"`
+	SuccessMessage string   `yaml:"success_message"`
+	Module         string   `yaml:"module"`
+}
+
+type CheckResult struct {
+	Dependency Dependency
+	Found      bool
+	FoundAt    string
+	Err        error
+}
+
+func RequiredDependencies(deps []Dependency) []Dependency {
+	req := make([]Dependency, 0, len(deps))
+	for _, dep := range deps {
+		if !dep.Optional {
+			req = append(req, dep)
+		}
+	}
+	return req
+}
+
+func OptionalDependencies(deps []Dependency) []Dependency {
+	opt := make([]Dependency, 0, len(deps))
+	for _, dep := range deps {
+		if dep.Optional {
+			opt = append(opt, dep)
+		}
+	}
+	return opt
+}
+
+func CheckRequiredDeps(ctx context.Context, spinnerText string, doneText string, failText string, deps []Dependency) bool {
+	allOK := true
+	p := pin.New(spinnerText,
+		pin.WithSpinnerColor(pin.ColorCyan),
+		pin.WithTextColor(pin.ColorGreen),
+		pin.WithDoneSymbol('\u2705'),
+		pin.WithFailSymbol('\u274c'),
+		pin.WithFailColor(pin.ColorRed),
+	)
+	cancel := p.Start(ctx)
+	defer cancel()
+	timer := time.After(SpinnerDelay)
+	checkResults, ok := Run(deps)
+	<-timer
+	if ok {
+		p.Stop(doneText)
+	} else {
+		p.Fail(failText)
+		allOK = false
+	}
+	PrintCheckResults(checkResults)
+	return allOK
+}
+
+func CheckOptionalDeps(ctx context.Context, spinnerText string, doneText string, failText string, deps []Dependency) {
+	if len(deps) == 0 {
+		return
+	}
+	fmt.Println()
+	p := pin.New(spinnerText,
+		pin.WithSpinnerColor(pin.ColorCyan),
+		pin.WithTextColor(pin.ColorGreen),
+		pin.WithDoneSymbol('\u2705'),
+		pin.WithFailSymbol('\u274c'),
+		pin.WithFailColor(pin.ColorYellow),
+	)
+	cancel := p.Start(ctx)
+	defer cancel()
+	timer := time.After(SpinnerDelay)
+	checkResults, ok := Run(deps)
+	<-timer
+	if ok {
+		p.Stop(doneText)
+	} else {
+		p.Fail(failText)
+	}
+	PrintCheckResults(checkResults)
+}
+
+func Run(dependencies []Dependency) ([]CheckResult, bool) {
+	checkResults := make([]CheckResult, 0, len(dependencies))
+	allOK := true
+	for _, dep := range dependencies {
+		var result CheckResult
+		switch dep.Type {
+		case TypeExecutable:
+			result = checkExeAvailable(dep)
+		case TypeDirectory:
+			result = checkDirNonEmpty(dep)
+		default:
+			result = CheckResult{
+				Dependency: dep,
+				Err:        fmt.Errorf("unknown dependency type: %s", dep.Type),
+			}
+		}
+		if result.Err != nil {
+			allOK = false
+		}
+		checkResults = append(checkResults, result)
+	}
+	return checkResults, allOK
+}
+
+func PrintCheckResults(checkResults []CheckResult) {
+	depParts := make([]string, 0, len(checkResults))
+	resultParts := make([]string, 0, len(checkResults))
+	for _, result := range checkResults {
+		tick := " > \u2705 "
+		outcome := result.FoundAt
+		if len(result.Dependency.SuccessMessage) > 0 {
+			outcome = lipgloss.Wrap(result.Dependency.SuccessMessage, 60, "")
+		}
+		if !result.Found {
+			tick = " > \u274c "
+			if len(result.Dependency.FailureMessage) > 0 {
+				outcome = lipgloss.Wrap(result.Dependency.FailureMessage, 60, "")
+			} else if result.Err != nil {
+				outcome = result.Err.Error()
+			}
+		}
+		description := result.Dependency.Description
+		if description == "" {
+			description = strings.Join(result.Dependency.Paths, "\n")
+		}
+		depPart := lipgloss.JoinHorizontal(lipgloss.Top, tick, description)
+		resultPart := lipgloss.JoinHorizontal(lipgloss.Top, " : ", outcome)
+		depParts = append(depParts, depPart)
+		resultParts = append(resultParts, resultPart)
+	}
+
+	out := lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		lipgloss.JoinVertical(lipgloss.Left, depParts...),
+		lipgloss.JoinVertical(lipgloss.Left, resultParts...),
+	)
+	lipgloss.Println("")
+	lipgloss.Println(out)
+}
+
+func checkExeAvailable(dep Dependency) CheckResult {
+	var errs error
+	for _, path := range dep.Paths {
+		location, err := exec.LookPath(path)
+		if err == nil {
+			return CheckResult{
+				Dependency: dep,
+				Found:      true,
+				FoundAt:    location,
+			}
+		}
+		errs = errors.Join(errs, err)
+	}
+	return CheckResult{
+		Dependency: dep,
+		Err:        errs,
+	}
+}
+
+func checkDirNonEmpty(dep Dependency) CheckResult {
+	var errs error
+	nonEmptyDirs := make([]string, 0)
+	for _, dir := range dep.Paths {
+		entries, err := os.ReadDir(dir)
+		if len(entries) > 0 {
+			nonEmptyDirs = append(nonEmptyDirs, dir)
+		} else {
+			errs = errors.Join(errs, err)
+		}
+	}
+	if len(nonEmptyDirs) > 0 {
+		return CheckResult{
+			Dependency: dep,
+			Found:      true,
+			FoundAt:    strings.Join(nonEmptyDirs, "\n"),
+		}
+	}
+	return CheckResult{
+		Dependency: dep,
+		Err:        errs,
+	}
+}

--- a/flight-core/doctor/doctor.go
+++ b/flight-core/doctor/doctor.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	TypeExecutable = "exe"
-	TypeDirectory  = "dir"
+	TypeExecutable   = "exe"
+	TypeDirectory    = "dir"
+	TypePythonModule = "python_module"
 )
 
 var SpinnerDelay = 1 * time.Second
@@ -116,6 +117,8 @@ func Run(dependencies []Dependency) ([]CheckResult, bool) {
 			result = checkExeAvailable(dep)
 		case TypeDirectory:
 			result = checkDirNonEmpty(dep)
+		case TypePythonModule:
+			result = checkPythonModule(dep)
 		default:
 			result = CheckResult{
 				Dependency: dep,
@@ -206,5 +209,34 @@ func checkDirNonEmpty(dep Dependency) CheckResult {
 	return CheckResult{
 		Dependency: dep,
 		Err:        errs,
+	}
+}
+
+func checkPythonModule(dep Dependency) CheckResult {
+	exeResult := checkExeAvailable(Dependency{Paths: dep.Paths})
+	if exeResult.Err != nil {
+		return CheckResult{
+			Dependency: dep,
+			Err:        exeResult.Err,
+		}
+	}
+
+	cmd := exec.Command(exeResult.FoundAt, "-c", fmt.Sprintf("import %s", dep.Module))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(output))
+		if msg == "" {
+			msg = err.Error()
+		}
+		return CheckResult{
+			Dependency: dep,
+			Err:        errors.New(msg),
+		}
+	}
+
+	return CheckResult{
+		Dependency: dep,
+		Found:      true,
+		FoundAt:    fmt.Sprintf("%s imports %s", exeResult.FoundAt, dep.Module),
 	}
 }

--- a/flight-core/doctor/doctor_test.go
+++ b/flight-core/doctor/doctor_test.go
@@ -1,0 +1,65 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunPythonModuleCheck(t *testing.T) {
+	tmpDir := t.TempDir()
+	pythonPath := filepath.Join(tmpDir, "python3")
+	script := "#!/bin/sh\ncase \"$2\" in\n  \"import pam\") exit 0 ;;\n  *) echo \"unexpected invocation: $*\" >&2; exit 2 ;;\nesac\n"
+	if err := os.WriteFile(pythonPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	t.Cleanup(func() {
+		_ = os.Setenv("PATH", origPath)
+	})
+	if err := os.Setenv("PATH", tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	results, ok := Run([]Dependency{{
+		Type:   TypePythonModule,
+		Paths:  []string{"python3"},
+		Module: "pam",
+	}})
+	if !ok {
+		t.Fatalf("expected python module check to pass, got %#v", results)
+	}
+	if len(results) != 1 || !results[0].Found {
+		t.Fatalf("expected single passing result, got %#v", results)
+	}
+}
+
+func TestRunPythonModuleCheckFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	pythonPath := filepath.Join(tmpDir, "python3")
+	script := "#!/bin/sh\necho \"ModuleNotFoundError: No module named 'pam'\" >&2\nexit 1\n"
+	if err := os.WriteFile(pythonPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	t.Cleanup(func() {
+		_ = os.Setenv("PATH", origPath)
+	})
+	if err := os.Setenv("PATH", tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	results, ok := Run([]Dependency{{
+		Type:   TypePythonModule,
+		Paths:  []string{"python3"},
+		Module: "pam",
+	}})
+	if ok {
+		t.Fatalf("expected python module check to fail, got %#v", results)
+	}
+	if len(results) != 1 || results[0].Err == nil {
+		t.Fatalf("expected single failing result, got %#v", results)
+	}
+}

--- a/flight-core/doctor_test.go
+++ b/flight-core/doctor_test.go
@@ -51,15 +51,12 @@ func TestWebDoctorHelp(t *testing.T) {
 
 func TestWebDoctorSuccess(t *testing.T) {
 	deps := setupWebDoctorTestDeps(t, false)
-	restoreDeps := swapWebDoctorDependencies(t, deps.general, deps.desktop)
+	restoreDeps := swapWebDoctorDependencies(t, deps.general)
 	defer restoreDeps()
 
 	output, err := runWebDoctorForTest(t)
 	if err != nil {
 		t.Fatalf("expected success, got %v\noutput:\n%s", err, output)
-	}
-	if !strings.Contains(output, "Required Flight Desktop access dependencies") {
-		t.Fatalf("expected desktop dependency section, got:\n%s", output)
 	}
 }
 
@@ -67,7 +64,7 @@ func TestWebDoctorFailsWhenPythonMissing(t *testing.T) {
 	deps := setupWebDoctorTestDeps(t, false)
 	deps.general[0].Paths = []string{"missing-python3"}
 	deps.general[1].Paths = []string{"missing-python3"}
-	restoreDeps := swapWebDoctorDependencies(t, deps.general, deps.desktop)
+	restoreDeps := swapWebDoctorDependencies(t, deps.general)
 	defer restoreDeps()
 
 	output, err := runWebDoctorForTest(t)
@@ -79,41 +76,13 @@ func TestWebDoctorFailsWhenPythonMissing(t *testing.T) {
 
 func TestWebDoctorFailsWhenPythonPamMissing(t *testing.T) {
 	deps := setupWebDoctorTestDeps(t, true)
-	restoreDeps := swapWebDoctorDependencies(t, deps.general, deps.desktop)
+	restoreDeps := swapWebDoctorDependencies(t, deps.general)
 	defer restoreDeps()
 
 	output, err := runWebDoctorForTest(t)
 	assertExitCodeOne(t, err, output)
 	if !strings.Contains(output, "Required general Flight Web Suite dependencies not satisfied") {
 		t.Fatalf("expected python-pam failure section, got:\n%s", output)
-	}
-}
-
-func TestWebDoctorFailsWhenWebsockifyMissing(t *testing.T) {
-	deps := setupWebDoctorTestDeps(t, false)
-	deps.desktop[0].Paths = []string{filepath.Join(t.TempDir(), "missing-websockify")}
-	restoreDeps := swapWebDoctorDependencies(t, deps.general, deps.desktop)
-	defer restoreDeps()
-
-	output, err := runWebDoctorForTest(t)
-	assertExitCodeOne(t, err, output)
-	if !strings.Contains(output, "Required Flight Desktop access dependencies not satisfied") {
-		t.Fatalf("expected websockify failure section, got:\n%s", output)
-	}
-}
-
-func TestWebDoctorOptionalImportMissingDoesNotFail(t *testing.T) {
-	deps := setupWebDoctorTestDeps(t, false)
-	deps.desktop[1].Paths = []string{filepath.Join(t.TempDir(), "missing-import")}
-	restoreDeps := swapWebDoctorDependencies(t, deps.general, deps.desktop)
-	defer restoreDeps()
-
-	output, err := runWebDoctorForTest(t)
-	if err != nil {
-		t.Fatalf("expected success with optional dependency missing, got %v\noutput:\n%s", err, output)
-	}
-	if !strings.Contains(output, "OPTIONAL Flight Desktop access dependencies not satisfied") {
-		t.Fatalf("expected optional warning, got:\n%s", output)
 	}
 }
 
@@ -131,7 +100,6 @@ func testRootCommand() *cli.Command {
 
 type webDoctorTestDeps struct {
 	general []doctor.Dependency
-	desktop []doctor.Dependency
 }
 
 func setupWebDoctorTestDeps(t *testing.T, failPam bool) webDoctorTestDeps {
@@ -139,58 +107,41 @@ func setupWebDoctorTestDeps(t *testing.T, failPam bool) webDoctorTestDeps {
 
 	tmpDir := t.TempDir()
 	pythonPath := filepath.Join(tmpDir, "python3")
-	websockifyPath := filepath.Join(tmpDir, "websockify")
-	importPath := filepath.Join(tmpDir, "import")
 
 	pythonScript := "#!/bin/sh\ncase \"$2\" in\n  \"import pam\") exit 0 ;;\n  *) echo \"unexpected invocation: $*\" >&2; exit 2 ;;\nesac\n"
 	if failPam {
 		pythonScript = "#!/bin/sh\necho \"ModuleNotFoundError: No module named 'pam'\" >&2\nexit 1\n"
 	}
 	writeToolFixture(t, pythonPath, 0o755, pythonScript)
-	writeToolFixture(t, websockifyPath, 0o755, "#!/bin/sh\nexit 0\n")
-	writeToolFixture(t, importPath, 0o755, "#!/bin/sh\nexit 0\n")
 
 	return webDoctorTestDeps{
 		general: []doctor.Dependency{
 			{
 				Type:        doctor.TypeExecutable,
 				Description: "Python 3",
-				Paths:       []string{"python3"},
+				Paths:       []string{pythonPath},
 			},
 			{
 				Type:        doctor.TypePythonModule,
 				Description: "python-pam",
-				Paths:       []string{"python3"},
+				Paths:       []string{pythonPath},
 				Module:      "pam",
-			},
-		},
-		desktop: []doctor.Dependency{
-			{
-				Type:        doctor.TypeExecutable,
-				Description: "Websockify",
-				Paths:       []string{websockifyPath},
-			},
-			{
-				Type:           doctor.TypeExecutable,
-				Description:    "ImageMagick import",
-				Optional:       true,
-				FailureMessage: "Screenshot capture for Flight Desktop access will not be available",
-				Paths:          []string{importPath},
 			},
 		},
 	}
 }
 
-func swapWebDoctorDependencies(t *testing.T, general []doctor.Dependency, desktop []doctor.Dependency) func() {
+// Replace dependencies with those provided as an argument.  This allows
+// controlling exactly which tests will fail and why.
+func swapWebDoctorDependencies(t *testing.T, general []doctor.Dependency) func() {
 	t.Helper()
 	prevGeneral := webDoctorGeneralDependencies
-	prevDesktop := webDoctorDesktopDependencies
 	prevDelay := doctor.SpinnerDelay
 	prevPath := os.Getenv("PATH")
 
 	pathParts := []string{}
 	seen := map[string]bool{}
-	for _, dep := range append(append([]doctor.Dependency{}, general...), desktop...) {
+	for _, dep := range general {
 		for _, path := range dep.Paths {
 			if filepath.IsAbs(path) {
 				dir := filepath.Dir(path)
@@ -211,11 +162,9 @@ func swapWebDoctorDependencies(t *testing.T, general []doctor.Dependency, deskto
 	}
 	doctor.SpinnerDelay = 0
 	webDoctorGeneralDependencies = general
-	webDoctorDesktopDependencies = desktop
 
 	return func() {
 		webDoctorGeneralDependencies = prevGeneral
-		webDoctorDesktopDependencies = prevDesktop
 		doctor.SpinnerDelay = prevDelay
 		_ = os.Setenv("PATH", prevPath)
 	}

--- a/flight-core/doctor_test.go
+++ b/flight-core/doctor_test.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/concertim/flight-user-suite/flight/doctor"
+	"github.com/urfave/cli/v3"
+)
+
+func TestWebHelpIncludesDoctor(t *testing.T) {
+	cmd := testRootCommand()
+	var out bytes.Buffer
+	cmd.Writer = &out
+	cmd.ErrWriter = &out
+
+	if err := cmd.Run(context.Background(), []string{"flight", "web", "--help"}); err != nil {
+		t.Fatal(err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "doctor  System health check for Flight Web Suite dependencies") {
+		t.Fatalf("expected web help to include doctor command, got:\n%s", output)
+	}
+}
+
+func TestWebDoctorHelp(t *testing.T) {
+	cmd := testRootCommand()
+	var out bytes.Buffer
+	cmd.Writer = &out
+	cmd.ErrWriter = &out
+
+	if err := cmd.Run(context.Background(), []string{"flight", "web", "doctor", "--help"}); err != nil {
+		t.Fatal(err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "flight web doctor [options]") {
+		t.Fatalf("expected doctor help usage, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Perform a health check on the system to check that all Flight Web Suite") ||
+		!strings.Contains(output, "dependencies are present.") {
+		t.Fatalf("expected doctor help description, got:\n%s", output)
+	}
+}
+
+func TestWebDoctorSuccess(t *testing.T) {
+	deps := setupWebDoctorTestDeps(t, false)
+	restoreDeps := swapWebDoctorDependencies(t, deps.general, deps.desktop)
+	defer restoreDeps()
+
+	output, err := runWebDoctorForTest(t)
+	if err != nil {
+		t.Fatalf("expected success, got %v\noutput:\n%s", err, output)
+	}
+	if !strings.Contains(output, "Required Flight Desktop access dependencies") {
+		t.Fatalf("expected desktop dependency section, got:\n%s", output)
+	}
+}
+
+func TestWebDoctorFailsWhenPythonMissing(t *testing.T) {
+	deps := setupWebDoctorTestDeps(t, false)
+	deps.general[0].Paths = []string{"missing-python3"}
+	deps.general[1].Paths = []string{"missing-python3"}
+	restoreDeps := swapWebDoctorDependencies(t, deps.general, deps.desktop)
+	defer restoreDeps()
+
+	output, err := runWebDoctorForTest(t)
+	assertExitCodeOne(t, err, output)
+	if !strings.Contains(output, "Required general Flight Web Suite dependencies not satisfied") {
+		t.Fatalf("expected python failure section, got:\n%s", output)
+	}
+}
+
+func TestWebDoctorFailsWhenPythonPamMissing(t *testing.T) {
+	deps := setupWebDoctorTestDeps(t, true)
+	restoreDeps := swapWebDoctorDependencies(t, deps.general, deps.desktop)
+	defer restoreDeps()
+
+	output, err := runWebDoctorForTest(t)
+	assertExitCodeOne(t, err, output)
+	if !strings.Contains(output, "Required general Flight Web Suite dependencies not satisfied") {
+		t.Fatalf("expected python-pam failure section, got:\n%s", output)
+	}
+}
+
+func TestWebDoctorFailsWhenWebsockifyMissing(t *testing.T) {
+	deps := setupWebDoctorTestDeps(t, false)
+	deps.desktop[0].Paths = []string{filepath.Join(t.TempDir(), "missing-websockify")}
+	restoreDeps := swapWebDoctorDependencies(t, deps.general, deps.desktop)
+	defer restoreDeps()
+
+	output, err := runWebDoctorForTest(t)
+	assertExitCodeOne(t, err, output)
+	if !strings.Contains(output, "Required Flight Desktop access dependencies not satisfied") {
+		t.Fatalf("expected websockify failure section, got:\n%s", output)
+	}
+}
+
+func TestWebDoctorOptionalImportMissingDoesNotFail(t *testing.T) {
+	deps := setupWebDoctorTestDeps(t, false)
+	deps.desktop[1].Paths = []string{filepath.Join(t.TempDir(), "missing-import")}
+	restoreDeps := swapWebDoctorDependencies(t, deps.general, deps.desktop)
+	defer restoreDeps()
+
+	output, err := runWebDoctorForTest(t)
+	if err != nil {
+		t.Fatalf("expected success with optional dependency missing, got %v\noutput:\n%s", err, output)
+	}
+	if !strings.Contains(output, "OPTIONAL Flight Desktop access dependencies not satisfied") {
+		t.Fatalf("expected optional warning, got:\n%s", output)
+	}
+}
+
+func testRootCommand() *cli.Command {
+	cmd := &cli.Command{
+		Name:                   progName,
+		Usage:                  "The Flight User Suite",
+		Version:                version,
+		UseShortOptionHandling: true,
+		HideHelpCommand:        true,
+	}
+	addAdminCommands(cmd, maxTextWidth)
+	return cmd
+}
+
+type webDoctorTestDeps struct {
+	general []doctor.Dependency
+	desktop []doctor.Dependency
+}
+
+func setupWebDoctorTestDeps(t *testing.T, failPam bool) webDoctorTestDeps {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	pythonPath := filepath.Join(tmpDir, "python3")
+	websockifyPath := filepath.Join(tmpDir, "websockify")
+	importPath := filepath.Join(tmpDir, "import")
+
+	pythonScript := "#!/bin/sh\ncase \"$2\" in\n  \"import pam\") exit 0 ;;\n  *) echo \"unexpected invocation: $*\" >&2; exit 2 ;;\nesac\n"
+	if failPam {
+		pythonScript = "#!/bin/sh\necho \"ModuleNotFoundError: No module named 'pam'\" >&2\nexit 1\n"
+	}
+	writeToolFixture(t, pythonPath, 0o755, pythonScript)
+	writeToolFixture(t, websockifyPath, 0o755, "#!/bin/sh\nexit 0\n")
+	writeToolFixture(t, importPath, 0o755, "#!/bin/sh\nexit 0\n")
+
+	return webDoctorTestDeps{
+		general: []doctor.Dependency{
+			{
+				Type:        doctor.TypeExecutable,
+				Description: "Python 3",
+				Paths:       []string{"python3"},
+			},
+			{
+				Type:        doctor.TypePythonModule,
+				Description: "python-pam",
+				Paths:       []string{"python3"},
+				Module:      "pam",
+			},
+		},
+		desktop: []doctor.Dependency{
+			{
+				Type:        doctor.TypeExecutable,
+				Description: "Websockify",
+				Paths:       []string{websockifyPath},
+			},
+			{
+				Type:           doctor.TypeExecutable,
+				Description:    "ImageMagick import",
+				Optional:       true,
+				FailureMessage: "Screenshot capture for Flight Desktop access will not be available",
+				Paths:          []string{importPath},
+			},
+		},
+	}
+}
+
+func swapWebDoctorDependencies(t *testing.T, general []doctor.Dependency, desktop []doctor.Dependency) func() {
+	t.Helper()
+	prevGeneral := webDoctorGeneralDependencies
+	prevDesktop := webDoctorDesktopDependencies
+	prevDelay := doctor.SpinnerDelay
+	prevPath := os.Getenv("PATH")
+
+	pathParts := []string{}
+	seen := map[string]bool{}
+	for _, dep := range append(append([]doctor.Dependency{}, general...), desktop...) {
+		for _, path := range dep.Paths {
+			if filepath.IsAbs(path) {
+				dir := filepath.Dir(path)
+				if !seen[dir] {
+					seen[dir] = true
+					pathParts = append(pathParts, dir)
+				}
+			}
+		}
+	}
+	if prevPath != "" {
+		pathParts = append(pathParts, prevPath)
+	}
+	if len(pathParts) > 0 {
+		if err := os.Setenv("PATH", strings.Join(pathParts, string(os.PathListSeparator))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	doctor.SpinnerDelay = 0
+	webDoctorGeneralDependencies = general
+	webDoctorDesktopDependencies = desktop
+
+	return func() {
+		webDoctorGeneralDependencies = prevGeneral
+		webDoctorDesktopDependencies = prevDesktop
+		doctor.SpinnerDelay = prevDelay
+		_ = os.Setenv("PATH", prevPath)
+	}
+}
+
+func runWebDoctorForTest(t *testing.T) (string, error) {
+	t.Helper()
+
+	stdout := os.Stdout
+	stderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	os.Stderr = w
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+	}()
+
+	runErr := runWebDoctor(context.Background(), &cli.Command{})
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String(), runErr
+}
+
+func assertExitCodeOne(t *testing.T, err error, output string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected exit code 1, got success\noutput:\n%s", output)
+	}
+	var exitErr cli.ExitCoder
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		t.Fatalf("expected exit code 1, got %v\noutput:\n%s", err, output)
+	}
+}

--- a/flight-core/main.go
+++ b/flight-core/main.go
@@ -385,6 +385,7 @@ The Flight Web Suite provides in-browser access to the Flight User Suite tools.`
 				startCommand(),
 				stopCommand(),
 				statusCommand(),
+				doctorCommand(),
 			},
 		},
 	}

--- a/flight-core/opt/flight/usr/share/doc/flight-web-suite/99-admin-guides/30-flight-web.md
+++ b/flight-core/opt/flight/usr/share/doc/flight-web-suite/99-admin-guides/30-flight-web.md
@@ -15,6 +15,15 @@ Flight Web Suite requires:
 * The [python-pam](https://pypi.org/project/python-pam/) library. Known as
   `python3-pampy` on Ubuntu. Known as `python3-pam` on Rocky 9 available from
   EPEL.
+
+You can verify these prerequisites with:
+
+```bash
+flight web doctor
+```
+
+If the Flight desktop tool is enabled:
+
 * `/usr/bin/websockify` to provide browser access to Flight Desktop sessions
 * Optionally, `/usr/bin/import` from ImageMagick to enable screenshot capture
   for Flight Desktop sessions
@@ -22,7 +31,7 @@ Flight Web Suite requires:
 You can verify these prerequisites with:
 
 ```bash
-flight web doctor
+flight desktop doctor
 ```
 
 ## Configuration
@@ -69,10 +78,6 @@ deployment configuration.
 The output of `flight web start` will include the URL at which Flight Web Suite
 can be accessed. Flight Web Suite uses the PAM `login` module to provide user
 authentication; users can log in with their cluster username and password.
-
-Flight Desktop access through Web Suite additionally depends on
-`/usr/bin/websockify`. If `/usr/bin/import` is also installed, Web Suite can
-capture and display desktop screenshots.
 
 In order to access Flight tools via Web Suite, the CLI counterparts to those
 tools will need to be enabled in the User Suite CLI tool (i.e. with

--- a/flight-core/opt/flight/usr/share/doc/flight-web-suite/99-admin-guides/30-flight-web.md
+++ b/flight-core/opt/flight/usr/share/doc/flight-web-suite/99-admin-guides/30-flight-web.md
@@ -15,6 +15,15 @@ Flight Web Suite requires:
 * The [python-pam](https://pypi.org/project/python-pam/) library. Known as
   `python3-pampy` on Ubuntu. Known as `python3-pam` on Rocky 9 available from
   EPEL.
+* `/usr/bin/websockify` to provide browser access to Flight Desktop sessions
+* Optionally, `/usr/bin/import` from ImageMagick to enable screenshot capture
+  for Flight Desktop sessions
+
+You can verify these prerequisites with:
+
+```bash
+flight web doctor
+```
 
 ## Configuration
 
@@ -49,11 +58,21 @@ deployment configuration.
   flight web status
   ```
 
+* **Check dependencies:** as `root` run
+
+  ```bash
+  flight web doctor
+  ```
+
 ## Accessing Flight Web
 
 The output of `flight web start` will include the URL at which Flight Web Suite
 can be accessed. Flight Web Suite uses the PAM `login` module to provide user
 authentication; users can log in with their cluster username and password.
+
+Flight Desktop access through Web Suite additionally depends on
+`/usr/bin/websockify`. If `/usr/bin/import` is also installed, Web Suite can
+capture and display desktop screenshots.
 
 In order to access Flight tools via Web Suite, the CLI counterparts to those
 tools will need to be enabled in the User Suite CLI tool (i.e. with

--- a/flight-core/opt/flight/usr/share/doc/flight-web-suite/99-admin-guides/30-flight-web.md
+++ b/flight-core/opt/flight/usr/share/doc/flight-web-suite/99-admin-guides/30-flight-web.md
@@ -67,7 +67,7 @@ deployment configuration.
   flight web status
   ```
 
-* **Check dependencies:** as `root` run
+* **Check dependencies:** run the following as a cluster admin user
 
   ```bash
   flight web doctor

--- a/flight-core/service_doctor.go
+++ b/flight-core/service_doctor.go
@@ -26,21 +26,6 @@ var webDoctorGeneralDependencies = []doctor.Dependency{
 	},
 }
 
-var webDoctorDesktopDependencies = []doctor.Dependency{
-	{
-		Type:        doctor.TypeExecutable,
-		Description: "Websockify",
-		Paths:       []string{"/usr/bin/websockify"},
-	},
-	{
-		Type:           doctor.TypeExecutable,
-		Description:    "ImageMagick import",
-		Optional:       true,
-		FailureMessage: "Screenshot capture for Flight Desktop access will not be available",
-		Paths:          []string{"/usr/bin/import"},
-	},
-}
-
 func doctorCommand() *cli.Command {
 	return &cli.Command{
 		Name:        "doctor",
@@ -61,25 +46,6 @@ func runWebDoctor(ctx context.Context, cmd *cli.Command) error {
 		"Required general Flight Web Suite dependencies",
 		"Required general Flight Web Suite dependencies not satisfied",
 		doctor.RequiredDependencies(webDoctorGeneralDependencies),
-	)
-
-	fmt.Println()
-	desktopAccessRequired := doctor.RequiredDependencies(webDoctorDesktopDependencies)
-	ok := doctor.CheckRequiredDeps(
-		ctx,
-		"Checking required Flight Desktop access dependencies...",
-		"Required Flight Desktop access dependencies",
-		"Required Flight Desktop access dependencies not satisfied",
-		desktopAccessRequired,
-	)
-	allOK = allOK && ok
-
-	doctor.CheckOptionalDeps(
-		ctx,
-		"Checking optional Flight Desktop access dependencies...",
-		"Optional Flight Desktop access dependencies",
-		"OPTIONAL Flight Desktop access dependencies not satisfied",
-		doctor.OptionalDependencies(webDoctorDesktopDependencies),
 	)
 
 	fmt.Println()

--- a/flight-core/service_doctor.go
+++ b/flight-core/service_doctor.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"charm.land/lipgloss/v2"
+	"github.com/concertim/flight-user-suite/flight/doctor"
+	"github.com/concertim/flight-user-suite/flight/userroles"
+	"github.com/muesli/reflow/wordwrap"
+	"github.com/urfave/cli/v3"
+)
+
+var webDoctorGeneralDependencies = []doctor.Dependency{
+	{
+		Type:        doctor.TypeExecutable,
+		Description: "Python 3",
+		Paths:       []string{"python3"},
+	},
+	{
+		Type:           doctor.TypePythonModule,
+		Description:    "Python PAM",
+		Paths:          []string{"python3"},
+		Module:         "pam",
+		FailureMessage: "Python PAM module (pam) not found",
+	},
+}
+
+var webDoctorDesktopDependencies = []doctor.Dependency{
+	{
+		Type:        doctor.TypeExecutable,
+		Description: "Websockify",
+		Paths:       []string{"/usr/bin/websockify"},
+	},
+	{
+		Type:           doctor.TypeExecutable,
+		Description:    "ImageMagick import",
+		Optional:       true,
+		FailureMessage: "Screenshot capture for Flight Desktop access will not be available",
+		Paths:          []string{"/usr/bin/import"},
+	},
+}
+
+func doctorCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "doctor",
+		Usage:       "System health check for Flight Web Suite dependencies",
+		Description: wordwrap.String("Perform a health check on the system to check that all Flight Web Suite dependencies are present.", maxTextWidth),
+		Action:      userroles.AsRoot(runWebDoctor),
+	}
+}
+
+func runWebDoctor(ctx context.Context, cmd *cli.Command) error {
+	greenText := lipgloss.NewStyle().Foreground(lipgloss.Green)
+	redText := lipgloss.NewStyle().Foreground(lipgloss.Red)
+
+	fmt.Println()
+	allOK := doctor.CheckRequiredDeps(
+		ctx,
+		"Checking required general Flight Web Suite dependencies...",
+		"Required general Flight Web Suite dependencies",
+		"Required general Flight Web Suite dependencies not satisfied",
+		doctor.RequiredDependencies(webDoctorGeneralDependencies),
+	)
+
+	fmt.Println()
+	desktopAccessRequired := doctor.RequiredDependencies(webDoctorDesktopDependencies)
+	ok := doctor.CheckRequiredDeps(
+		ctx,
+		"Checking required Flight Desktop access dependencies...",
+		"Required Flight Desktop access dependencies",
+		"Required Flight Desktop access dependencies not satisfied",
+		desktopAccessRequired,
+	)
+	allOK = allOK && ok
+
+	doctor.CheckOptionalDeps(
+		ctx,
+		"Checking optional Flight Desktop access dependencies...",
+		"Optional Flight Desktop access dependencies",
+		"OPTIONAL Flight Desktop access dependencies not satisfied",
+		doctor.OptionalDependencies(webDoctorDesktopDependencies),
+	)
+
+	fmt.Println()
+	if allOK {
+		lipgloss.Println(greenText.Render("\u2705 All required dependencies satisfied"))
+		return nil
+	}
+
+	lipgloss.Println(redText.Render("\u274c Required dependencies not satisfied"))
+	return cli.Exit("", 1)
+}

--- a/flight-desktop/config.go
+++ b/flight-desktop/config.go
@@ -9,12 +9,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/concertim/flight-user-suite/flight/doctor"
 	"gopkg.in/yaml.v3"
 )
 
 type desktopConfig struct {
 	NameGenerator nameGeneratorConfig `yaml:"name_generator"`
-	Dependencies  []dependency        `yaml:"dependencies"`
+	Dependencies  []doctor.Dependency `yaml:"dependencies"`
 	EnvWhitelist  []string            `yaml:"environment_whitelist"`
 	VncPasswd     string              `yaml:"vncpasswd"`
 	WebSockify    string              `yaml:"websockify"`
@@ -23,35 +24,6 @@ type desktopConfig struct {
 
 type nameGeneratorConfig struct {
 	Strategy string `yaml:"strategy"`
-}
-
-type dependency struct {
-	Type           string   `yaml:"type"`
-	Description    string   `yaml:"description"`
-	Optional       bool     `yaml:"optional"`
-	Paths          []string `yaml:"paths"`
-	FailureMessage string   `yaml:"failure_message"`
-	SuccessMessage string   `yaml:"success_message"`
-}
-
-func requiredDependencies(deps []dependency) []dependency {
-	opt := make([]dependency, 0)
-	for _, dep := range deps {
-		if !dep.Optional {
-			opt = append(opt, dep)
-		}
-	}
-	return opt
-}
-
-func optionalDependencies(deps []dependency) []dependency {
-	opt := make([]dependency, 0)
-	for _, dep := range deps {
-		if dep.Optional {
-			opt = append(opt, dep)
-		}
-	}
-	return opt
 }
 
 //go:embed opt/flight/etc/desktop.yml

--- a/flight-desktop/config_test.go
+++ b/flight-desktop/config_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/concertim/flight-user-suite/flight/configenv"
+	"github.com/concertim/flight-user-suite/flight/doctor"
+)
+
+func TestLoadDefaultConfigIncludesWebSuiteDesktopDependencies(t *testing.T) {
+	prevEnv := env
+	t.Cleanup(func() {
+		env = prevEnv
+	})
+	env = configenv.RepoLocalFlightEnv(t.TempDir())
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertHasDependency(t, cfg.Dependencies, doctor.Dependency{
+		Type:        doctor.TypeExecutable,
+		Description: "Websockify",
+		Optional:    true,
+		Paths:       []string{"/usr/bin/websockify"},
+	})
+	assertHasDependency(t, cfg.Dependencies, doctor.Dependency{
+		Type:        doctor.TypeExecutable,
+		Description: "ImageMagick - screenshot support",
+		Optional:    true,
+		Paths:       []string{"/usr/bin/import"},
+	})
+}
+
+func assertHasDependency(t *testing.T, deps []doctor.Dependency, want doctor.Dependency) {
+	t.Helper()
+	for _, dep := range deps {
+		if dep.Type == want.Type &&
+			dep.Description == want.Description &&
+			dep.Optional == want.Optional &&
+			len(dep.Paths) == len(want.Paths) &&
+			dep.Paths[0] == want.Paths[0] {
+			return
+		}
+	}
+	t.Fatalf("expected dependency %#v in %#v", want, deps)
+}

--- a/flight-desktop/doctor.go
+++ b/flight-desktop/doctor.go
@@ -3,17 +3,13 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
-	"time"
 
 	"charm.land/lipgloss/v2"
+	"github.com/concertim/flight-user-suite/flight/doctor"
 	"github.com/muesli/reflow/wordwrap"
 	"github.com/urfave/cli/v3"
-	"github.com/yarlson/pin"
 )
 
 func doctorCommand() *cli.Command {
@@ -25,25 +21,25 @@ func doctorCommand() *cli.Command {
 		Flags:       []cli.Flag{formatFlag},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.String("format") == "json" {
-				report := buildDoctorReport(ctx)
+				report := buildDoctorReport()
 				return writeChecksJSON(report)
 			}
 			greenText := lipgloss.NewStyle().Foreground(lipgloss.Green)
 			redText := lipgloss.NewStyle().Foreground(lipgloss.Red)
 			fmt.Println()
-			allOK := checkRequiredDeps(
+			allOK := doctor.CheckRequiredDeps(
 				ctx,
 				"Checking critical dependencies...",
 				"Critical dependencies",
 				"Critical dependencies not satisfied",
-				requiredDependencies(config.Dependencies),
+				doctor.RequiredDependencies(config.Dependencies),
 			)
-			checkOptionalDeps(
+			doctor.CheckOptionalDeps(
 				ctx,
 				"Checking optional dependencies...",
 				"Optional dependencies",
 				"OPTIONAL dependencies not satisfied",
-				optionalDependencies(config.Dependencies),
+				doctor.OptionalDependencies(config.Dependencies),
 			)
 
 			types, err := loadAllTypes(false)
@@ -62,20 +58,20 @@ func doctorCommand() *cli.Command {
 						allOK = false
 						continue
 					}
-					ok := checkRequiredDeps(
+					ok := doctor.CheckRequiredDeps(
 						ctx,
 						fmt.Sprintf("Checking required dependencies for %s desktop type.", typ.ID),
 						fmt.Sprintf("Required dependencies for %s desktop type", typ.ID),
 						fmt.Sprintf("Missing required dependencies for %s desktop type", typ.ID),
-						requiredDependencies(typ.dependencies),
+						doctor.RequiredDependencies(typ.dependencies),
 					)
 					allOK = allOK && ok
-					checkOptionalDeps(
+					doctor.CheckOptionalDeps(
 						ctx,
 						fmt.Sprintf("Checking optional dependencies for %s desktop type.", typ.ID),
 						fmt.Sprintf("Optional dependencies for %s desktop type", typ.ID),
 						fmt.Sprintf("OPTIONAL dependencies for %s desktop type are not satisfied", typ.ID),
-						optionalDependencies(typ.dependencies),
+						doctor.OptionalDependencies(typ.dependencies),
 					)
 				}
 			}
@@ -84,12 +80,12 @@ func doctorCommand() *cli.Command {
 				msg := greenText.Render("\u2705 All required dependencies satisfied")
 				lipgloss.Println(msg)
 				return nil
-			} else {
-				fmt.Println()
-				msg := redText.Render("\u274c Required dependencies not satisfied")
-				lipgloss.Println(msg)
-				return cli.Exit("", 1)
 			}
+
+			fmt.Println()
+			msg := redText.Render("\u274c Required dependencies not satisfied")
+			lipgloss.Println(msg)
+			return cli.Exit("", 1)
 		},
 	}
 }
@@ -107,196 +103,34 @@ type checkResultJSON struct {
 	Error       string   `json:"error,omitempty"`
 }
 
-type checkResult struct {
-	dependency dependency
-	found      bool
-	foundAt    string
-	err        error
-}
-
 func writeChecksJSON(report doctorReport) error {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	return enc.Encode(report)
 }
 
-func toJSONResults(results []checkResult) []checkResultJSON {
+func toJSONResults(results []doctor.CheckResult) []checkResultJSON {
 	jsonResults := make([]checkResultJSON, 0, len(results))
 	for _, r := range results {
 		item := checkResultJSON{
-			Description: r.dependency.Description,
-			Paths:       r.dependency.Paths,
-			Optional:    r.dependency.Optional,
-			Found:       r.found,
+			Description: r.Dependency.Description,
+			Paths:       r.Dependency.Paths,
+			Optional:    r.Dependency.Optional,
+			Found:       r.Found,
 		}
-		if r.err != nil {
-			item.Error = r.err.Error()
+		if r.Err != nil {
+			item.Error = r.Err.Error()
 		}
 		jsonResults = append(jsonResults, item)
 	}
 	return jsonResults
 }
 
-func buildDoctorReport(ctx context.Context) doctorReport {
-	coreRequired := requiredDependencies(config.Dependencies)
-	coreResults, coreOK := runDoctor(coreRequired)
-	report := doctorReport{
+func buildDoctorReport() doctorReport {
+	coreRequired := doctor.RequiredDependencies(config.Dependencies)
+	coreResults, coreOK := doctor.Run(coreRequired)
+	return doctorReport{
 		OK:     coreOK,
 		Checks: toJSONResults(coreResults),
-	}
-	return report
-}
-
-func checkRequiredDeps(ctx context.Context, spinnerText string, doneText string, failText string, deps []dependency) bool {
-	allOK := true
-	p := pin.New(spinnerText,
-		pin.WithSpinnerColor(pin.ColorCyan),
-		pin.WithTextColor(pin.ColorGreen),
-		pin.WithDoneSymbol('\u2705'),
-		pin.WithFailSymbol('\u274c'),
-		pin.WithFailColor(pin.ColorRed),
-	)
-	cancel := p.Start(ctx)
-	defer cancel()
-	checkResults, ok := runDoctor(deps)
-	<-time.After(1 * time.Second)
-	if ok {
-		p.Stop(doneText)
-	} else {
-		p.Fail(failText)
-		allOK = false
-	}
-	printCheckResults(checkResults)
-	return allOK
-}
-
-func checkOptionalDeps(ctx context.Context, spinnerText string, doneText string, failText string, deps []dependency) {
-	if len(deps) == 0 {
-		return
-	}
-	fmt.Println()
-	p := pin.New(spinnerText,
-		pin.WithSpinnerColor(pin.ColorCyan),
-		pin.WithTextColor(pin.ColorGreen),
-		pin.WithDoneSymbol('\u2705'),
-		pin.WithFailSymbol('\u274c'),
-		pin.WithFailColor(pin.ColorYellow),
-	)
-	cancel := p.Start(ctx)
-	defer cancel()
-	checkResults, ok := runDoctor(deps)
-	<-time.After(1 * time.Second)
-	if ok {
-		p.Stop(doneText)
-	} else {
-		p.Fail(failText)
-	}
-	printCheckResults(checkResults)
-}
-
-func runDoctor(dependencies []dependency) ([]checkResult, bool) {
-	checkResults := make([]checkResult, 0)
-	allOK := true
-	for _, dep := range dependencies {
-		switch dep.Type {
-		case "exe":
-			result := checkExeAvailable(dep)
-			if result.err != nil {
-				allOK = false
-			}
-			checkResults = append(checkResults, result)
-		case "dir":
-			result := checkDirNonEmpty(dep)
-			if result.err != nil {
-				allOK = false
-			}
-			checkResults = append(checkResults, result)
-		}
-	}
-	return checkResults, allOK
-}
-
-func printCheckResults(checkResults []checkResult) {
-	depParts := make([]string, 0, len(checkResults))
-	resultParts := make([]string, 0, len(checkResults))
-	for _, result := range checkResults {
-		tick := " > \u2705 "
-		outcome := result.foundAt
-		if len(result.dependency.SuccessMessage) > 0 {
-			outcome = lipgloss.Wrap(result.dependency.SuccessMessage, 60, "")
-		}
-		if !result.found {
-			tick = " > \u274c "
-			if len(result.dependency.FailureMessage) > 0 {
-				outcome = lipgloss.Wrap(result.dependency.FailureMessage, 60, "")
-			} else {
-				outcome = result.err.Error()
-			}
-		}
-		description := result.dependency.Description
-		if description == "" {
-			description = strings.Join(result.dependency.Paths, "\n")
-		}
-		depPart := lipgloss.JoinHorizontal(lipgloss.Top, tick, description)
-		resultPart := lipgloss.JoinHorizontal(lipgloss.Top, " : ", outcome)
-		depParts = append(depParts, depPart)
-		resultParts = append(resultParts, resultPart)
-	}
-
-	out := lipgloss.JoinHorizontal(
-		lipgloss.Top,
-		lipgloss.JoinVertical(lipgloss.Left, depParts...),
-		lipgloss.JoinVertical(lipgloss.Left, resultParts...),
-	)
-	lipgloss.Println("")
-	lipgloss.Println(out)
-}
-
-func checkExeAvailable(dep dependency) checkResult {
-	var errs error
-	for _, path := range dep.Paths {
-		location, err := exec.LookPath(path)
-		if err == nil {
-			return checkResult{
-				dependency: dep,
-				found:      true,
-				foundAt:    location,
-				err:        nil,
-			}
-		}
-		errs = errors.Join(errs, err)
-	}
-	return checkResult{
-		dependency: dep,
-		found:      false,
-		foundAt:    "",
-		err:        errs,
-	}
-}
-
-func checkDirNonEmpty(dep dependency) checkResult {
-	var errs error
-	nonEmptyDirs := make([]string, 0)
-	for _, dir := range dep.Paths {
-		entries, err := os.ReadDir(dir)
-		if len(entries) > 0 {
-			nonEmptyDirs = append(nonEmptyDirs, dir)
-		} else {
-			errs = errors.Join(errs, err)
-		}
-	}
-	if len(nonEmptyDirs) > 0 {
-		return checkResult{
-			dependency: dep,
-			found:      true,
-			foundAt:    strings.Join(nonEmptyDirs, "\n"),
-			err:        nil,
-		}
-	}
-	return checkResult{
-		dependency: dep,
-		found:      false,
-		foundAt:    "",
-		err:        errs,
 	}
 }

--- a/flight-desktop/session_start.go
+++ b/flight-desktop/session_start.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/concertim/flight-user-suite/flight/doctor"
 	"github.com/muesli/reflow/wordwrap"
 	"github.com/urfave/cli/v3"
 	"github.com/yarlson/pin"
@@ -280,11 +281,11 @@ func checkDependencies(ctx context.Context, sessionType string) (bool, error) {
 	// Add a small delay to stop the spinner from flickering
 	<-time.After(1 * time.Second)
 
-	globalResults, globalDepsOK := runDoctor(requiredDependencies(config.Dependencies))
+	globalResults, globalDepsOK := doctor.Run(doctor.RequiredDependencies(config.Dependencies))
 
 	if !globalDepsOK {
 		p.Fail("Missing critical dependencies")
-		printCheckResults(globalResults)
+		doctor.PrintCheckResults(globalResults)
 		return false, nil
 	}
 
@@ -299,11 +300,11 @@ func checkDependencies(ctx context.Context, sessionType string) (bool, error) {
 		return false, err
 	}
 
-	typeResults, typeDepsOK := runDoctor(requiredDependencies(sessionTypeDef.dependencies))
+	typeResults, typeDepsOK := doctor.Run(doctor.RequiredDependencies(sessionTypeDef.dependencies))
 
 	if !typeDepsOK {
 		p.Fail(fmt.Sprintf("Missing required dependencies for %s desktop type", sessionType))
-		printCheckResults(typeResults)
+		doctor.PrintCheckResults(typeResults)
 		return false, err
 	}
 
@@ -313,7 +314,7 @@ func checkDependencies(ctx context.Context, sessionType string) (bool, error) {
 }
 
 func checkDependenciesQuiet(sessionType string) (bool, error) {
-	_, globalDepsOK := runDoctor(requiredDependencies(config.Dependencies))
+	_, globalDepsOK := doctor.Run(doctor.RequiredDependencies(config.Dependencies))
 	if !globalDepsOK {
 		return false, nil
 	}
@@ -326,7 +327,7 @@ func checkDependenciesQuiet(sessionType string) (bool, error) {
 		return false, err
 	}
 
-	_, typeDepsOK := runDoctor(requiredDependencies(sessionTypeDef.dependencies))
+	_, typeDepsOK := doctor.Run(doctor.RequiredDependencies(sessionTypeDef.dependencies))
 	if !typeDepsOK {
 		return false, nil
 	}

--- a/flight-desktop/type.go
+++ b/flight-desktop/type.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"charm.land/log/v2"
+	"github.com/concertim/flight-user-suite/flight/doctor"
 	"gopkg.in/yaml.v3"
 )
 
@@ -63,7 +64,7 @@ type Type struct {
 	Summary               string `json:"summary" yaml:"summary"`
 	URL                   string `json:"url" yaml:"url"`
 	IsAvailable           bool   `json:"available" yaml:"available"`
-	dependencies          []dependency
+	dependencies          []doctor.Dependency
 	dependenciesLoadError error
 }
 
@@ -76,7 +77,7 @@ func (t *Type) loadDependencies() error {
 	if err != nil {
 		return fmt.Errorf("loading dependencies for %s: %w", t.ID, err)
 	}
-	var deps []dependency
+	var deps []doctor.Dependency
 	err = yaml.Unmarshal(data, &deps)
 	if err != nil {
 		return fmt.Errorf("loading config from %s: %w", path, err)
@@ -89,7 +90,7 @@ func (t *Type) checkDependencies() {
 	t.IsAvailable = false
 	t.dependenciesLoadError = t.loadDependencies()
 	if t.dependenciesLoadError == nil {
-		if _, depsOK := runDoctor(requiredDependencies(t.dependencies)); depsOK {
+		if _, depsOK := doctor.Run(doctor.RequiredDependencies(t.dependencies)); depsOK {
 			t.IsAvailable = true
 		}
 	}


### PR DESCRIPTION
This PR adds support for checking web suite dependencies via a `flight web doctor` command.

The checking of desktop web access dependencies has remained in `desktop doctor` so that it can be ran on a variety of machines.  Running `desktop doctor` on a visualisation node where desktop sessions might be started, seems to make more sense to me than running `web doctor` on a node where FWS will never run.

Checking desktop web access dependencies could have been duplicated in `web doctor`.  However, the machine that FWS is to run on might not be intended as a desktop target and might not have desktop enabled on that machine or its dependencies installed.

On balance, the better solution is to have `web doctor` only check for general (aka core) dependencies.

```bash
$ flight web doctor

✅ Required general Flight Web Suite dependencies

 > ✅ Python 3   : /usr/bin/python3            
 > ✅ Python PAM : /usr/bin/python3 imports pam

✅ All required dependencies satisfied
```

If the checks fail, it is expected that the user will read the find documentation to understand what needs to be installed.

### Implementation

* The doctor related routes and types have been extracted to a new `doctor` package and `flight-desktop` updated.
* A new dependency type `python_module` has been added.  It checks that `python3 -c 'import <module>'` exits successfully.
* A new `web doctor` command has been added.  The dependencies it checks are hardcoded.  I see no point in allowing them to be configurable, when the `authenticate.py` script effectively hardcodes them too.