### PR TITLE
Improve check for webified remote sessions

### DIFF
--- a/flight-desktop/session.go
+++ b/flight-desktop/session.go
@@ -145,7 +145,7 @@ func (s Session) IsWebified() bool {
 		return s.WebsocketPid != 0 && process.IsRunning(s.WebsocketPid)
 	case "remote":
 		// TODO: SSH to the machine its running on and check if its webified.
-		return true
+		return s.WebsocketPid != 0
 	default:
 		return false
 	}


### PR DESCRIPTION
If a remote session has ever started a websockify process, assume it is webified.  Whilst not fully correct, it is a _big_ improvement.

Refs #190 